### PR TITLE
Method to terminate all players

### DIFF
--- a/CoreZen/Cache/ObjectCache.h
+++ b/CoreZen/Cache/ObjectCache.h
@@ -19,4 +19,7 @@
 - (void)cacheObject:(id<ZENIdentifiable>)object;
 - (void)removeObject:(ZENIdentifier)identifier;
 
+- (NSArray<id<ZENIdentifiable>> *)allCachedObjects;
+- (void)removeAllObjects;
+
 @end

--- a/CoreZen/Cache/ObjectCache.m
+++ b/CoreZen/Cache/ObjectCache.m
@@ -66,7 +66,7 @@
 		NSNumber *identifier = @(object.identifier);
 		id existing = [self.mapTable objectForKey:identifier];
 		// There must be either no entry, or the entry expired because nothing was holding a strong ref
-		if (!existing || existing == [NSNull null]) {
+		if (!existing || existing == NSNull.null) {
 			[self.mapTable setObject:object forKey:identifier];
 		}
 	});
@@ -75,6 +75,25 @@
 - (void)removeObject:(ZENIdentifier)identifier {
 	dispatch_barrier_async(self.isolationQueue, ^{
 		[self.mapTable removeObjectForKey:@(identifier)];
+	});
+}
+
+- (NSArray<id<ZENIdentifiable>> *)allCachedObjects {
+	__block NSMutableArray<id<ZENIdentifiable>> *objs = [NSMutableArray new];
+	dispatch_sync(self.isolationQueue, ^{
+		NSEnumerator<id<ZENIdentifiable>> *enumerator = self.mapTable.objectEnumerator;
+		for (id obj in enumerator) {
+			if (obj && obj != NSNull.null) {
+				[objs addObject:obj];
+			}
+		}
+	});
+	return objs;
+}
+
+- (void)removeAllObjects {
+	dispatch_barrier_async(self.isolationQueue, ^{
+		[self.mapTable removeAllObjects];
 	});
 }
 

--- a/CoreZen/Media/MediaPlayer.h
+++ b/CoreZen/Media/MediaPlayer.h
@@ -6,10 +6,11 @@
 //
 
 #import <Foundation/Foundation.h>
+#import <CoreZen/Identifiable.h>
 
 @class ZENMediaPlayerView;
 
-@interface ZENMediaPlayer : NSObject
+@interface ZENMediaPlayer : NSObject <ZENIdentifiable>
 
 - (instancetype)initWithFileURL:(NSURL*)url;
 

--- a/CoreZen/Media/MediaPlayer.h
+++ b/CoreZen/Media/MediaPlayer.h
@@ -23,6 +23,9 @@
 // Terminate and detach the player view, terminate player controller
 - (void)terminatePlayer;
 
+// Call before application terminates to terminate all ZENMediaPlayer instances
++ (void)terminateAllPlayers;
+
 - (void)startPlayback;
 - (void)pausePlayback;
 

--- a/CoreZen/Media/MediaPlayer.m
+++ b/CoreZen/Media/MediaPlayer.m
@@ -57,6 +57,15 @@ ZENIdentifier ZENGetNextMediaPlayerIdentifier(void) {
 	[cache removeObject:self.identifier];
 }
 
++ (void)terminateAllPlayers {
+	ZENObjectCache *cache = ZENGetWeakMediaPlayerCache();
+	NSArray<id<ZENIdentifiable>> *objs = cache.allCachedObjects;
+	for (ZENMediaPlayer *player in objs) {
+		[player terminatePlayer];
+	}
+	[cache removeAllObjects];
+}
+
 - (void)attachPlayerView:(ZENMediaPlayerView *)view {
 	self.playerView = view;
 }

--- a/CoreZen/Media/MediaPlayer.m
+++ b/CoreZen/Media/MediaPlayer.m
@@ -8,6 +8,18 @@
 #import "MediaPlayer+Private.h"
 #import "MediaPlayerView+Private.h"
 #import "MPVPlayerController.h"
+#import <stdatomic.h>
+
+ZENIdentifier ZENGetNextMediaPlayerIdentifier(void) {
+	static atomic_int_fast64_t nextIdentifier = 1;
+	return atomic_fetch_add(&nextIdentifier, 1);
+}
+
+@interface ZENMediaPlayer ()
+
+@property (nonatomic) ZENIdentifier identifier;
+
+@end
 
 @implementation ZENMediaPlayer
 
@@ -16,6 +28,7 @@
 	if (self) {
 		_fileURL = url;
 		_playerController = [[ZENMPVPlayerController alloc] initWithPlayer:self];
+		_identifier = ZENGetNextMediaPlayerIdentifier();
 	}
 	return self;
 }


### PR DESCRIPTION
Added `+terminateAllPlayers` which uses a weak cache of all players ever initialized to terminate players before shutdown.