### PR TITLE
Checkpoint on libav frame renderer

### DIFF
--- a/CoreZen.xcodeproj/project.pbxproj
+++ b/CoreZen.xcodeproj/project.pbxproj
@@ -40,6 +40,9 @@
 		5316736D2909CC66003FB35A /* ArchivedView.m in Sources */ = {isa = PBXBuildFile; fileRef = 5316736B2909CC66003FB35A /* ArchivedView.m */; };
 		532CA223291B090E008FA673 /* FrameRenderer.h in Headers */ = {isa = PBXBuildFile; fileRef = 532CA221291B090E008FA673 /* FrameRenderer.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		532CA224291B090E008FA673 /* FrameRenderer.m in Sources */ = {isa = PBXBuildFile; fileRef = 532CA222291B090E008FA673 /* FrameRenderer.m */; };
+		532CA22A291B0CFB008FA673 /* LibAVInfoController.h in Headers */ = {isa = PBXBuildFile; fileRef = 532CA228291B0CFB008FA673 /* LibAVInfoController.h */; };
+		532CA22B291B0CFB008FA673 /* LibAVInfoController.m in Sources */ = {isa = PBXBuildFile; fileRef = 532CA229291B0CFB008FA673 /* LibAVInfoController.m */; };
+		532CA22C291B0E44008FA673 /* MediaInfoController.h in Headers */ = {isa = PBXBuildFile; fileRef = 532CA227291B0CA4008FA673 /* MediaInfoController.h */; };
 		533005DE28F784B600E59E1D /* ZENMediaPlayerControlsView.xib in Resources */ = {isa = PBXBuildFile; fileRef = 533005DD28F784B600E59E1D /* ZENMediaPlayerControlsView.xib */; };
 		5350F8A42886020500F8CA68 /* DatabaseTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 5350F8A32886020500F8CA68 /* DatabaseTests.m */; };
 		5350F8B42886074F00F8CA68 /* ObjectCacheTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 5350F8B32886074F00F8CA68 /* ObjectCacheTests.m */; };
@@ -329,6 +332,9 @@
 		532CA221291B090E008FA673 /* FrameRenderer.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = FrameRenderer.h; sourceTree = "<group>"; };
 		532CA222291B090E008FA673 /* FrameRenderer.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = FrameRenderer.m; sourceTree = "<group>"; };
 		532CA226291B09E6008FA673 /* MediaFile+Private.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "MediaFile+Private.h"; sourceTree = "<group>"; };
+		532CA227291B0CA4008FA673 /* MediaInfoController.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MediaInfoController.h; sourceTree = "<group>"; };
+		532CA228291B0CFB008FA673 /* LibAVInfoController.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = LibAVInfoController.h; sourceTree = "<group>"; };
+		532CA229291B0CFB008FA673 /* LibAVInfoController.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = LibAVInfoController.m; sourceTree = "<group>"; };
 		533005DD28F784B600E59E1D /* ZENMediaPlayerControlsView.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = ZENMediaPlayerControlsView.xib; sourceTree = "<group>"; };
 		5350F8A32886020500F8CA68 /* DatabaseTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = DatabaseTests.m; sourceTree = "<group>"; };
 		5350F8B32886074F00F8CA68 /* ObjectCacheTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = ObjectCacheTests.m; sourceTree = "<group>"; };
@@ -768,6 +774,15 @@
 			path = Nibs;
 			sourceTree = "<group>";
 		};
+		532CA225291B097A008FA673 /* LibAV */ = {
+			isa = PBXGroup;
+			children = (
+				532CA228291B0CFB008FA673 /* LibAVInfoController.h */,
+				532CA229291B0CFB008FA673 /* LibAVInfoController.m */,
+			);
+			path = LibAV;
+			sourceTree = "<group>";
+		};
 		5350F8B52886079F00F8CA68 /* Classes */ = {
 			isa = PBXGroup;
 			children = (
@@ -781,6 +796,7 @@
 			isa = PBXGroup;
 			children = (
 				53D85BA22900BE7300A7B134 /* Interfaces */,
+				532CA225291B097A008FA673 /* LibAV */,
 				53965322288F1601007B53EC /* MPV */,
 				5316736E2909CE9B003FB35A /* Views */,
 				5350F8C02886194200F8CA68 /* MediaFile.h */,
@@ -1165,6 +1181,7 @@
 		53D85BA22900BE7300A7B134 /* Interfaces */ = {
 			isa = PBXGroup;
 			children = (
+				532CA227291B0CA4008FA673 /* MediaInfoController.h */,
 				5396531E288CE2A7007B53EC /* MediaPlayerController.h */,
 				5396532F288F498B007B53EC /* MediaPlayerRenderController.h */,
 				5356FE7228A459BA00ECCA92 /* MediaPlayer+Private.h */,
@@ -1207,9 +1224,11 @@
 				532CA223291B090E008FA673 /* FrameRenderer.h in Headers */,
 				5316736C2909CC66003FB35A /* ArchivedView.h in Headers */,
 				5386706E28BFE16300FB15EB /* MediaPlayerControlsView.h in Headers */,
+				532CA22C291B0E44008FA673 /* MediaInfoController.h in Headers */,
 				53965331288F498B007B53EC /* MediaPlayerRenderController.h in Headers */,
 				53965320288CE2A7007B53EC /* MediaPlayerController.h in Headers */,
 				5396531C288CD19C007B53EC /* MediaPlayerView.h in Headers */,
+				532CA22A291B0CFB008FA673 /* LibAVInfoController.h in Headers */,
 				5309C3BA2885A1DC00BC0AAE /* CoreZen.h in Headers */,
 				53965339288F4DF9007B53EC /* MPVFunctions.h in Headers */,
 				5356FE5828A4290000ECCA92 /* MPVConstants.h in Headers */,
@@ -1266,7 +1285,7 @@
 			isa = PBXProject;
 			attributes = {
 				BuildIndependentTargetsInParallel = 1;
-				LastUpgradeCheck = 1340;
+				LastUpgradeCheck = 1410;
 				TargetAttributes = {
 					5309C3A82885A1DC00BC0AAE = {
 						CreatedOnToolsVersion = 13.4.1;
@@ -1325,6 +1344,7 @@
 				5309C4222885CB1400BC0AAE /* DataTransferObject.m in Sources */,
 				5386706C28BFE16300FB15EB /* MediaPlayerControlsView.m in Sources */,
 				5396531D288CD19C007B53EC /* MediaPlayerView.m in Sources */,
+				532CA22B291B0CFB008FA673 /* LibAVInfoController.m in Sources */,
 				5396533A288F4DF9007B53EC /* MPVFunctions.m in Sources */,
 				532CA224291B090E008FA673 /* FrameRenderer.m in Sources */,
 				5309C4262885CDA500BC0AAE /* DatabaseSchema.m in Sources */,
@@ -1406,6 +1426,7 @@
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
 				COPY_PHASE_STRIP = NO;
 				CURRENT_PROJECT_VERSION = 1;
+				DEAD_CODE_STRIPPING = YES;
 				DEBUG_INFORMATION_FORMAT = dwarf;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
 				ENABLE_TESTABILITY = YES;
@@ -1423,6 +1444,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
+				MACOSX_DEPLOYMENT_TARGET = 12.5;
 				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
 				MTL_FAST_MATH = YES;
 				ONLY_ACTIVE_ARCH = NO;
@@ -1466,6 +1488,7 @@
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
 				COPY_PHASE_STRIP = NO;
 				CURRENT_PROJECT_VERSION = 1;
+				DEAD_CODE_STRIPPING = YES;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				ENABLE_NS_ASSERTIONS = NO;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
@@ -1477,6 +1500,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
+				MACOSX_DEPLOYMENT_TARGET = 12.5;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				MTL_FAST_MATH = YES;
 				SDKROOT = macosx;
@@ -1493,6 +1517,7 @@
 				CODE_SIGN_STYLE = Manual;
 				COMBINE_HIDPI_IMAGES = YES;
 				CURRENT_PROJECT_VERSION = 1;
+				DEAD_CODE_STRIPPING = YES;
 				DEFINES_MODULE = YES;
 				DEVELOPMENT_TEAM = 5N7Y5W34VF;
 				DYLIB_COMPATIBILITY_VERSION = 1;
@@ -1513,6 +1538,7 @@
 					"@loader_path/Frameworks",
 				);
 				LIBRARY_SEARCH_PATHS = "$(PROJECT_DIR)/Dependencies/lib";
+				MACOSX_DEPLOYMENT_TARGET = 12.5;
 				MARKETING_VERSION = 1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.zdnelson.CoreZen;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
@@ -1530,6 +1556,7 @@
 				CODE_SIGN_STYLE = Manual;
 				COMBINE_HIDPI_IMAGES = YES;
 				CURRENT_PROJECT_VERSION = 1;
+				DEAD_CODE_STRIPPING = YES;
 				DEFINES_MODULE = YES;
 				DEVELOPMENT_TEAM = 5N7Y5W34VF;
 				DYLIB_COMPATIBILITY_VERSION = 1;
@@ -1550,6 +1577,7 @@
 					"@loader_path/Frameworks",
 				);
 				LIBRARY_SEARCH_PATHS = "$(PROJECT_DIR)/Dependencies/lib";
+				MACOSX_DEPLOYMENT_TARGET = 12.5;
 				MARKETING_VERSION = 1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.zdnelson.CoreZen;
 				PRODUCT_NAME = "$(TARGET_NAME:c99extidentifier)";
@@ -1565,6 +1593,7 @@
 				CODE_SIGN_IDENTITY = "Developer ID Application";
 				CODE_SIGN_STYLE = Manual;
 				CURRENT_PROJECT_VERSION = 1;
+				DEAD_CODE_STRIPPING = YES;
 				DEVELOPMENT_TEAM = 5N7Y5W34VF;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
@@ -1585,6 +1614,7 @@
 				CODE_SIGN_IDENTITY = "Developer ID Application";
 				CODE_SIGN_STYLE = Manual;
 				CURRENT_PROJECT_VERSION = 1;
+				DEAD_CODE_STRIPPING = YES;
 				DEVELOPMENT_TEAM = 5N7Y5W34VF;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",

--- a/CoreZen.xcodeproj/project.pbxproj
+++ b/CoreZen.xcodeproj/project.pbxproj
@@ -38,6 +38,8 @@
 		531673692909C1F7003FB35A /* ZENMediaPlayerCTIView.xib in Resources */ = {isa = PBXBuildFile; fileRef = 531673682909C1F7003FB35A /* ZENMediaPlayerCTIView.xib */; };
 		5316736C2909CC66003FB35A /* ArchivedView.h in Headers */ = {isa = PBXBuildFile; fileRef = 5316736A2909CC66003FB35A /* ArchivedView.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		5316736D2909CC66003FB35A /* ArchivedView.m in Sources */ = {isa = PBXBuildFile; fileRef = 5316736B2909CC66003FB35A /* ArchivedView.m */; };
+		532CA223291B090E008FA673 /* FrameRenderer.h in Headers */ = {isa = PBXBuildFile; fileRef = 532CA221291B090E008FA673 /* FrameRenderer.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		532CA224291B090E008FA673 /* FrameRenderer.m in Sources */ = {isa = PBXBuildFile; fileRef = 532CA222291B090E008FA673 /* FrameRenderer.m */; };
 		533005DE28F784B600E59E1D /* ZENMediaPlayerControlsView.xib in Resources */ = {isa = PBXBuildFile; fileRef = 533005DD28F784B600E59E1D /* ZENMediaPlayerControlsView.xib */; };
 		5350F8A42886020500F8CA68 /* DatabaseTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 5350F8A32886020500F8CA68 /* DatabaseTests.m */; };
 		5350F8B42886074F00F8CA68 /* ObjectCacheTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 5350F8B32886074F00F8CA68 /* ObjectCacheTests.m */; };
@@ -324,6 +326,8 @@
 		531673682909C1F7003FB35A /* ZENMediaPlayerCTIView.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = ZENMediaPlayerCTIView.xib; sourceTree = "<group>"; };
 		5316736A2909CC66003FB35A /* ArchivedView.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ArchivedView.h; sourceTree = "<group>"; };
 		5316736B2909CC66003FB35A /* ArchivedView.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = ArchivedView.m; sourceTree = "<group>"; };
+		532CA221291B090E008FA673 /* FrameRenderer.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = FrameRenderer.h; sourceTree = "<group>"; };
+		532CA222291B090E008FA673 /* FrameRenderer.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = FrameRenderer.m; sourceTree = "<group>"; };
 		532CA226291B09E6008FA673 /* MediaFile+Private.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "MediaFile+Private.h"; sourceTree = "<group>"; };
 		533005DD28F784B600E59E1D /* ZENMediaPlayerControlsView.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = ZENMediaPlayerControlsView.xib; sourceTree = "<group>"; };
 		5350F8A32886020500F8CA68 /* DatabaseTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = DatabaseTests.m; sourceTree = "<group>"; };
@@ -783,6 +787,8 @@
 				5350F8C12886194200F8CA68 /* MediaFile.m */,
 				53964F11288CC101007B53EC /* MediaPlayer.h */,
 				53964F12288CC101007B53EC /* MediaPlayer.m */,
+				532CA221291B090E008FA673 /* FrameRenderer.h */,
+				532CA222291B090E008FA673 /* FrameRenderer.m */,
 			);
 			path = Media;
 			sourceTree = "<group>";
@@ -1198,6 +1204,7 @@
 				5356FE7428A459BA00ECCA92 /* MediaPlayer+Private.h in Headers */,
 				5356FE7028A4595800ECCA92 /* MediaPlayerView+Private.h in Headers */,
 				531673662909C1DD003FB35A /* MediaPlayerCTIView.h in Headers */,
+				532CA223291B090E008FA673 /* FrameRenderer.h in Headers */,
 				5316736C2909CC66003FB35A /* ArchivedView.h in Headers */,
 				5386706E28BFE16300FB15EB /* MediaPlayerControlsView.h in Headers */,
 				53965331288F498B007B53EC /* MediaPlayerRenderController.h in Headers */,
@@ -1319,6 +1326,7 @@
 				5386706C28BFE16300FB15EB /* MediaPlayerControlsView.m in Sources */,
 				5396531D288CD19C007B53EC /* MediaPlayerView.m in Sources */,
 				5396533A288F4DF9007B53EC /* MPVFunctions.m in Sources */,
+				532CA224291B090E008FA673 /* FrameRenderer.m in Sources */,
 				5309C4262885CDA500BC0AAE /* DatabaseSchema.m in Sources */,
 				5309C3AE2885A1DC00BC0AAE /* CoreZen.docc in Sources */,
 				538E05142885ED2200CE9DE7 /* ObjectRepository.m in Sources */,

--- a/CoreZen.xcodeproj/project.pbxproj
+++ b/CoreZen.xcodeproj/project.pbxproj
@@ -47,6 +47,7 @@
 		532CA234291B1E96008FA673 /* LibAVRenderController.h in Headers */ = {isa = PBXBuildFile; fileRef = 532CA232291B1E96008FA673 /* LibAVRenderController.h */; };
 		532CA235291B1E96008FA673 /* LibAVRenderController.m in Sources */ = {isa = PBXBuildFile; fileRef = 532CA233291B1E96008FA673 /* LibAVRenderController.m */; };
 		532CA236291B1F73008FA673 /* FrameRenderController.h in Headers */ = {isa = PBXBuildFile; fileRef = 532CA22F291B1B85008FA673 /* FrameRenderController.h */; };
+		532CA23D291D8152008FA673 /* FrameRendererTypes.h in Headers */ = {isa = PBXBuildFile; fileRef = 532CA23C291D8152008FA673 /* FrameRendererTypes.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		533005DE28F784B600E59E1D /* ZENMediaPlayerControlsView.xib in Resources */ = {isa = PBXBuildFile; fileRef = 533005DD28F784B600E59E1D /* ZENMediaPlayerControlsView.xib */; };
 		5350F8A42886020500F8CA68 /* DatabaseTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 5350F8A32886020500F8CA68 /* DatabaseTests.m */; };
 		5350F8B42886074F00F8CA68 /* ObjectCacheTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 5350F8B32886074F00F8CA68 /* ObjectCacheTests.m */; };
@@ -343,6 +344,7 @@
 		532CA230291B1C8B008FA673 /* FrameRenderer+Private.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "FrameRenderer+Private.h"; sourceTree = "<group>"; };
 		532CA232291B1E96008FA673 /* LibAVRenderController.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = LibAVRenderController.h; sourceTree = "<group>"; };
 		532CA233291B1E96008FA673 /* LibAVRenderController.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = LibAVRenderController.m; sourceTree = "<group>"; };
+		532CA23C291D8152008FA673 /* FrameRendererTypes.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = FrameRendererTypes.h; path = CoreZen/Media/FrameRendererTypes.h; sourceTree = SOURCE_ROOT; };
 		533005DD28F784B600E59E1D /* ZENMediaPlayerControlsView.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = ZENMediaPlayerControlsView.xib; sourceTree = "<group>"; };
 		5350F8A32886020500F8CA68 /* DatabaseTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = DatabaseTests.m; sourceTree = "<group>"; };
 		5350F8B32886074F00F8CA68 /* ObjectCacheTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = ObjectCacheTests.m; sourceTree = "<group>"; };
@@ -627,6 +629,7 @@
 				539A16D128DA209A007D001A /* libavfilter.8.dylib in Frameworks */,
 				539A167A28DA209A007D001A /* libavformat.59.dylib in Frameworks */,
 				539A168628DA209A007D001A /* libavutil.57.dylib in Frameworks */,
+				532CA237291C5C65008FA673 /* libswscale.6.dylib in Frameworks */,
 				539A16A128DA209A007D001A /* libmpv.1.dylib in Frameworks */,
 				538499112885FF21004ED6A1 /* FMDB.framework in Frameworks */,
 			);
@@ -813,6 +816,7 @@
 				5350F8C12886194200F8CA68 /* MediaFile.m */,
 				53964F11288CC101007B53EC /* MediaPlayer.h */,
 				53964F12288CC101007B53EC /* MediaPlayer.m */,
+				532CA23C291D8152008FA673 /* FrameRendererTypes.h */,
 				532CA221291B090E008FA673 /* FrameRenderer.h */,
 				532CA222291B090E008FA673 /* FrameRenderer.m */,
 			);
@@ -1234,6 +1238,7 @@
 				5356FE7028A4595800ECCA92 /* MediaPlayerView+Private.h in Headers */,
 				531673662909C1DD003FB35A /* MediaPlayerCTIView.h in Headers */,
 				532CA223291B090E008FA673 /* FrameRenderer.h in Headers */,
+				532CA23D291D8152008FA673 /* FrameRendererTypes.h in Headers */,
 				5316736C2909CC66003FB35A /* ArchivedView.h in Headers */,
 				532CA234291B1E96008FA673 /* LibAVRenderController.h in Headers */,
 				532CA236291B1F73008FA673 /* FrameRenderController.h in Headers */,

--- a/CoreZen.xcodeproj/project.pbxproj
+++ b/CoreZen.xcodeproj/project.pbxproj
@@ -324,6 +324,7 @@
 		531673682909C1F7003FB35A /* ZENMediaPlayerCTIView.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = ZENMediaPlayerCTIView.xib; sourceTree = "<group>"; };
 		5316736A2909CC66003FB35A /* ArchivedView.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ArchivedView.h; sourceTree = "<group>"; };
 		5316736B2909CC66003FB35A /* ArchivedView.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = ArchivedView.m; sourceTree = "<group>"; };
+		532CA226291B09E6008FA673 /* MediaFile+Private.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "MediaFile+Private.h"; sourceTree = "<group>"; };
 		533005DD28F784B600E59E1D /* ZENMediaPlayerControlsView.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = ZENMediaPlayerControlsView.xib; sourceTree = "<group>"; };
 		5350F8A32886020500F8CA68 /* DatabaseTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = DatabaseTests.m; sourceTree = "<group>"; };
 		5350F8B32886074F00F8CA68 /* ObjectCacheTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = ObjectCacheTests.m; sourceTree = "<group>"; };
@@ -1162,6 +1163,7 @@
 				5396532F288F498B007B53EC /* MediaPlayerRenderController.h */,
 				5356FE7228A459BA00ECCA92 /* MediaPlayer+Private.h */,
 				5356FE6E28A4595800ECCA92 /* MediaPlayerView+Private.h */,
+				532CA226291B09E6008FA673 /* MediaFile+Private.h */,
 			);
 			path = Interfaces;
 			sourceTree = "<group>";

--- a/CoreZen.xcodeproj/project.pbxproj
+++ b/CoreZen.xcodeproj/project.pbxproj
@@ -47,6 +47,7 @@
 		532CA234291B1E96008FA673 /* LibAVRenderController.h in Headers */ = {isa = PBXBuildFile; fileRef = 532CA232291B1E96008FA673 /* LibAVRenderController.h */; };
 		532CA235291B1E96008FA673 /* LibAVRenderController.m in Sources */ = {isa = PBXBuildFile; fileRef = 532CA233291B1E96008FA673 /* LibAVRenderController.m */; };
 		532CA236291B1F73008FA673 /* FrameRenderController.h in Headers */ = {isa = PBXBuildFile; fileRef = 532CA22F291B1B85008FA673 /* FrameRenderController.h */; };
+		532CA237291C5C65008FA673 /* libswscale.6.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = 539A15B128DA2099007D001A /* libswscale.6.dylib */; };
 		532CA23D291D8152008FA673 /* FrameRendererTypes.h in Headers */ = {isa = PBXBuildFile; fileRef = 532CA23C291D8152008FA673 /* FrameRendererTypes.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		533005DE28F784B600E59E1D /* ZENMediaPlayerControlsView.xib in Resources */ = {isa = PBXBuildFile; fileRef = 533005DD28F784B600E59E1D /* ZENMediaPlayerControlsView.xib */; };
 		5350F8A42886020500F8CA68 /* DatabaseTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 5350F8A32886020500F8CA68 /* DatabaseTests.m */; };

--- a/CoreZen.xcodeproj/project.pbxproj
+++ b/CoreZen.xcodeproj/project.pbxproj
@@ -43,6 +43,10 @@
 		532CA22A291B0CFB008FA673 /* LibAVInfoController.h in Headers */ = {isa = PBXBuildFile; fileRef = 532CA228291B0CFB008FA673 /* LibAVInfoController.h */; };
 		532CA22B291B0CFB008FA673 /* LibAVInfoController.m in Sources */ = {isa = PBXBuildFile; fileRef = 532CA229291B0CFB008FA673 /* LibAVInfoController.m */; };
 		532CA22C291B0E44008FA673 /* MediaInfoController.h in Headers */ = {isa = PBXBuildFile; fileRef = 532CA227291B0CA4008FA673 /* MediaInfoController.h */; };
+		532CA231291B1C8B008FA673 /* FrameRenderer+Private.h in Headers */ = {isa = PBXBuildFile; fileRef = 532CA230291B1C8B008FA673 /* FrameRenderer+Private.h */; };
+		532CA234291B1E96008FA673 /* LibAVRenderController.h in Headers */ = {isa = PBXBuildFile; fileRef = 532CA232291B1E96008FA673 /* LibAVRenderController.h */; };
+		532CA235291B1E96008FA673 /* LibAVRenderController.m in Sources */ = {isa = PBXBuildFile; fileRef = 532CA233291B1E96008FA673 /* LibAVRenderController.m */; };
+		532CA236291B1F73008FA673 /* FrameRenderController.h in Headers */ = {isa = PBXBuildFile; fileRef = 532CA22F291B1B85008FA673 /* FrameRenderController.h */; };
 		533005DE28F784B600E59E1D /* ZENMediaPlayerControlsView.xib in Resources */ = {isa = PBXBuildFile; fileRef = 533005DD28F784B600E59E1D /* ZENMediaPlayerControlsView.xib */; };
 		5350F8A42886020500F8CA68 /* DatabaseTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 5350F8A32886020500F8CA68 /* DatabaseTests.m */; };
 		5350F8B42886074F00F8CA68 /* ObjectCacheTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 5350F8B32886074F00F8CA68 /* ObjectCacheTests.m */; };
@@ -335,6 +339,10 @@
 		532CA227291B0CA4008FA673 /* MediaInfoController.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MediaInfoController.h; sourceTree = "<group>"; };
 		532CA228291B0CFB008FA673 /* LibAVInfoController.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = LibAVInfoController.h; sourceTree = "<group>"; };
 		532CA229291B0CFB008FA673 /* LibAVInfoController.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = LibAVInfoController.m; sourceTree = "<group>"; };
+		532CA22F291B1B85008FA673 /* FrameRenderController.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = FrameRenderController.h; sourceTree = "<group>"; };
+		532CA230291B1C8B008FA673 /* FrameRenderer+Private.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "FrameRenderer+Private.h"; sourceTree = "<group>"; };
+		532CA232291B1E96008FA673 /* LibAVRenderController.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = LibAVRenderController.h; sourceTree = "<group>"; };
+		532CA233291B1E96008FA673 /* LibAVRenderController.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = LibAVRenderController.m; sourceTree = "<group>"; };
 		533005DD28F784B600E59E1D /* ZENMediaPlayerControlsView.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = ZENMediaPlayerControlsView.xib; sourceTree = "<group>"; };
 		5350F8A32886020500F8CA68 /* DatabaseTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = DatabaseTests.m; sourceTree = "<group>"; };
 		5350F8B32886074F00F8CA68 /* ObjectCacheTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = ObjectCacheTests.m; sourceTree = "<group>"; };
@@ -779,6 +787,8 @@
 			children = (
 				532CA228291B0CFB008FA673 /* LibAVInfoController.h */,
 				532CA229291B0CFB008FA673 /* LibAVInfoController.m */,
+				532CA232291B1E96008FA673 /* LibAVRenderController.h */,
+				532CA233291B1E96008FA673 /* LibAVRenderController.m */,
 			);
 			path = LibAV;
 			sourceTree = "<group>";
@@ -1182,11 +1192,13 @@
 			isa = PBXGroup;
 			children = (
 				532CA227291B0CA4008FA673 /* MediaInfoController.h */,
+				532CA22F291B1B85008FA673 /* FrameRenderController.h */,
 				5396531E288CE2A7007B53EC /* MediaPlayerController.h */,
 				5396532F288F498B007B53EC /* MediaPlayerRenderController.h */,
 				5356FE7228A459BA00ECCA92 /* MediaPlayer+Private.h */,
 				5356FE6E28A4595800ECCA92 /* MediaPlayerView+Private.h */,
 				532CA226291B09E6008FA673 /* MediaFile+Private.h */,
+				532CA230291B1C8B008FA673 /* FrameRenderer+Private.h */,
 			);
 			path = Interfaces;
 			sourceTree = "<group>";
@@ -1223,6 +1235,9 @@
 				531673662909C1DD003FB35A /* MediaPlayerCTIView.h in Headers */,
 				532CA223291B090E008FA673 /* FrameRenderer.h in Headers */,
 				5316736C2909CC66003FB35A /* ArchivedView.h in Headers */,
+				532CA234291B1E96008FA673 /* LibAVRenderController.h in Headers */,
+				532CA236291B1F73008FA673 /* FrameRenderController.h in Headers */,
+				532CA231291B1C8B008FA673 /* FrameRenderer+Private.h in Headers */,
 				5386706E28BFE16300FB15EB /* MediaPlayerControlsView.h in Headers */,
 				532CA22C291B0E44008FA673 /* MediaInfoController.h in Headers */,
 				53965331288F498B007B53EC /* MediaPlayerRenderController.h in Headers */,
@@ -1363,6 +1378,7 @@
 				53965336288F4C37007B53EC /* MPVViewLayer.m in Sources */,
 				5309C4102885B43B00BC0AAE /* ObjectCache.m in Sources */,
 				5309C40B2885B15400BC0AAE /* NSNumber+CoreZen.m in Sources */,
+				532CA235291B1E96008FA673 /* LibAVRenderController.m in Sources */,
 				5356FE5928A4290000ECCA92 /* MPVConstants.m in Sources */,
 				538E050C2885E53700CE9DE7 /* DomainCommon.m in Sources */,
 				5309C4022885B11400BC0AAE /* NSFileManager+CoreZen.m in Sources */,

--- a/CoreZen/CoreZen.h
+++ b/CoreZen/CoreZen.h
@@ -42,6 +42,7 @@ FOUNDATION_EXPORT const unsigned char CoreZenVersionString[];
 #import <CoreZen/ObjectIdentifier.h>
 
 #pragma mark - Media
+#import <CoreZen/FrameRenderer.h>
 #import <CoreZen/MediaFile.h>
 #import <CoreZen/MediaPlayer.h>
 #import <CoreZen/MediaPlayerView.h>

--- a/CoreZen/Media/FrameRenderer.h
+++ b/CoreZen/Media/FrameRenderer.h
@@ -1,0 +1,12 @@
+//
+//  FrameRenderer.h
+//  CoreZen
+//
+//  Created by Zach Nelson on 11/8/22.
+//
+
+#import <Foundation/Foundation.h>
+
+@interface ZENFrameRenderer : NSObject
+
+@end

--- a/CoreZen/Media/FrameRenderer.h
+++ b/CoreZen/Media/FrameRenderer.h
@@ -6,11 +6,41 @@
 //
 
 #import <Foundation/Foundation.h>
+#import <CoreZen/FrameRendererTypes.h>
+
+// Rendered frame result
+@interface ZENRenderedFrame : NSObject
+
+// The rendered video frame image
+@property (nonatomic, strong) NSImage *image;
+
+// The requested position of the frame
+@property (nonatomic) int64_t requestedTimestamp;
+@property (nonatomic) double requestedSeconds;
+@property (nonatomic) double requestedPercentage;
+
+// The actual rendered position of the frame
+@property (nonatomic) int64_t actualTimestamp;
+@property (nonatomic) double actualSeconds;
+@property (nonatomic) double actualPercentage;
+
+@end
 
 @protocol ZENFrameRenderController;
 
+// Interface for requesting rendered frames
 @interface ZENFrameRenderer : NSObject
 
 - (instancetype)initWithController:(NSObject<ZENFrameRenderController> *)controller;
+
+- (void)renderFrameAtSeconds:(double)seconds
+					   width:(NSUInteger)width
+					  height:(NSUInteger)height
+				  completion:(ZENFrameRendererResultsBlock)completion;
+
+- (void)renderFrameAtPercentage:(double)percentage
+						  width:(NSUInteger)width
+						 height:(NSUInteger)height
+					 completion:(ZENFrameRendererResultsBlock)completion;
 
 @end

--- a/CoreZen/Media/FrameRenderer.h
+++ b/CoreZen/Media/FrameRenderer.h
@@ -7,6 +7,10 @@
 
 #import <Foundation/Foundation.h>
 
+@protocol ZENFrameRenderController;
+
 @interface ZENFrameRenderer : NSObject
+
+- (instancetype)initWithController:(NSObject<ZENFrameRenderController> *)controller;
 
 @end

--- a/CoreZen/Media/FrameRenderer.m
+++ b/CoreZen/Media/FrameRenderer.m
@@ -1,0 +1,12 @@
+//
+//  FrameRenderer.m
+//  CoreZen
+//
+//  Created by Zach Nelson on 11/8/22.
+//
+
+#import "FrameRenderer.h"
+
+@implementation ZENFrameRenderer
+
+@end

--- a/CoreZen/Media/FrameRenderer.m
+++ b/CoreZen/Media/FrameRenderer.m
@@ -6,7 +6,22 @@
 //
 
 #import "FrameRenderer.h"
+#import "FrameRenderController.h"
+
+@interface ZENFrameRenderer ()
+
+@property (nonatomic, strong) NSObject<ZENFrameRenderController> *frameRenderController;
+
+@end
 
 @implementation ZENFrameRenderer
+
+- (instancetype)initWithController:(NSObject<ZENFrameRenderController> *)controller {
+	self = [super init];
+	if (self) {
+		_frameRenderController = controller;
+	}
+	return self;
+}
 
 @end

--- a/CoreZen/Media/FrameRenderer.m
+++ b/CoreZen/Media/FrameRenderer.m
@@ -5,12 +5,13 @@
 //  Created by Zach Nelson on 11/8/22.
 //
 
-#import "FrameRenderer.h"
+#import "FrameRenderer+Private.h"
 #import "FrameRenderController.h"
 
-@interface ZENFrameRenderer ()
+@implementation ZENRenderedFrame
+@end
 
-@property (nonatomic, strong) NSObject<ZENFrameRenderController> *frameRenderController;
+@interface ZENFrameRenderer ()
 
 @end
 
@@ -22,6 +23,28 @@
 		_frameRenderController = controller;
 	}
 	return self;
+}
+
+- (void)renderFrameAtSeconds:(double)seconds
+					   width:(NSUInteger)width
+					  height:(NSUInteger)height
+				  completion:(ZENFrameRendererResultsBlock)completion {
+	
+	ZENRenderedFrame *frame = [ZENRenderedFrame new];
+	frame.requestedSeconds = seconds;
+	
+	[self.frameRenderController renderFrame:frame size:NSMakeSize(width, height) completion:completion];
+}
+
+- (void)renderFrameAtPercentage:(double)percentage
+						  width:(NSUInteger)width
+						 height:(NSUInteger)height
+					 completion:(ZENFrameRendererResultsBlock)completion {
+	
+	ZENRenderedFrame *frame = [ZENRenderedFrame new];
+	frame.requestedPercentage = percentage;
+	
+	[self.frameRenderController renderFrame:frame size:NSMakeSize(width, height) completion:completion];
 }
 
 @end

--- a/CoreZen/Media/FrameRendererTypes.h
+++ b/CoreZen/Media/FrameRendererTypes.h
@@ -1,0 +1,13 @@
+//
+//  FrameRendererTypes.h
+//  CoreZen
+//
+//  Created by Zach Nelson on 11/10/22.
+//
+
+#import <Foundation/Foundation.h>
+
+@class ZENRenderedFrame;
+
+// Completion block type
+typedef void (^ZENFrameRendererResultsBlock)(ZENRenderedFrame *frame);

--- a/CoreZen/Media/Interfaces/FrameRenderController.h
+++ b/CoreZen/Media/Interfaces/FrameRenderController.h
@@ -6,9 +6,14 @@
 //
 
 #import <Foundation/Foundation.h>
+#import <CoreZen/FrameRendererTypes.h>
 
 @protocol ZENFrameRenderController <NSObject>
 
 - (void)terminate;
+
+- (void)renderFrame:(ZENRenderedFrame *)frame
+			   size:(NSSize)size
+		 completion:(ZENFrameRendererResultsBlock)completion;
 
 @end

--- a/CoreZen/Media/Interfaces/FrameRenderController.h
+++ b/CoreZen/Media/Interfaces/FrameRenderController.h
@@ -1,0 +1,14 @@
+//
+//  FrameRenderController.h
+//  CoreZen
+//
+//  Created by Zach Nelson on 11/8/22.
+//
+
+#import <Foundation/Foundation.h>
+
+@protocol ZENFrameRenderController <NSObject>
+
+- (void)terminate;
+
+@end

--- a/CoreZen/Media/Interfaces/FrameRenderer+Private.h
+++ b/CoreZen/Media/Interfaces/FrameRenderer+Private.h
@@ -1,0 +1,16 @@
+//
+//  FrameRenderer+Private.h
+//  CoreZen
+//
+//  Created by Zach Nelson on 11/8/22.
+//
+
+#import <CoreZen/FrameRenderer.h>
+
+@protocol ZENFrameRenderController;
+
+@interface ZENFrameRenderer ()
+
+@property (nonatomic, strong, readonly) NSObject<ZENFrameRenderController> *frameRenderController;
+
+@end

--- a/CoreZen/Media/Interfaces/MediaFile+Private.h
+++ b/CoreZen/Media/Interfaces/MediaFile+Private.h
@@ -1,0 +1,12 @@
+//
+//  MediaFile+Private.h
+//  CoreZen
+//
+//  Created by Zach Nelson on 11/8/22.
+//
+
+#import <CoreZen/MediaFile.h>
+
+@interface ZENMediaFile ()
+
+@end

--- a/CoreZen/Media/Interfaces/MediaFile+Private.h
+++ b/CoreZen/Media/Interfaces/MediaFile+Private.h
@@ -7,6 +7,10 @@
 
 #import <CoreZen/MediaFile.h>
 
+@protocol ZENMediaInfoController;
+
 @interface ZENMediaFile ()
+
+@property (nonatomic, strong, readonly) NSObject<ZENMediaInfoController> *mediaInfoController;
 
 @end

--- a/CoreZen/Media/Interfaces/MediaInfoController.h
+++ b/CoreZen/Media/Interfaces/MediaInfoController.h
@@ -13,6 +13,9 @@
 
 - (NSObject<ZENFrameRenderController> *)frameRenderController;
 
+// (AVFormatContext *)formatContextHandle;
+- (void *)formatContextHandle;
+
 // (const AVCodec *)videoCodecHandle;
 - (const void *)videoCodecHandle;
 
@@ -22,6 +25,7 @@
 - (void)terminate;
 
 - (NSUInteger)durationMicroseconds;
+- (double)durationSeconds;
 
 - (NSUInteger)frameWidth;
 - (NSUInteger)frameHeight;

--- a/CoreZen/Media/Interfaces/MediaInfoController.h
+++ b/CoreZen/Media/Interfaces/MediaInfoController.h
@@ -1,0 +1,25 @@
+//
+//  MediaInfoController.h
+//  CoreZen
+//
+//  Created by Zach Nelson on 11/8/22.
+//
+
+#import <Foundation/Foundation.h>
+
+@protocol ZENMediaInfoController <NSObject>
+
+- (void)terminate;
+
+- (NSUInteger)durationMicroseconds;
+
+- (NSUInteger)frameWidth;
+- (NSUInteger)frameHeight;
+
+- (NSString *)videoCodecName;
+- (NSString *)audioCodecName;
+
+- (NSString *)videoCodecLongName;
+- (NSString *)audioCodecLongName;
+
+@end

--- a/CoreZen/Media/Interfaces/MediaInfoController.h
+++ b/CoreZen/Media/Interfaces/MediaInfoController.h
@@ -7,7 +7,23 @@
 
 #import <Foundation/Foundation.h>
 
+@protocol ZENFrameRenderController;
+
 @protocol ZENMediaInfoController <NSObject>
+
+- (NSObject<ZENFrameRenderController> *)frameRenderController;
+
+// (const AVCodec *)videoCodecHandle;
+- (const void *)videoCodecHandle;
+
+// (const AVCodec *)audioCodecHandle;
+- (const void *)audioCodecHandle;
+
+// (const AVCodecParameters *)videoCodecParamsHandle;
+- (const void *)videoCodecParamsHandle;
+
+// (const AVCodecParameters *)audioCodecParamsHandle;
+- (const void *)audioCodecParamsHandle;
 
 - (void)terminate;
 

--- a/CoreZen/Media/Interfaces/MediaInfoController.h
+++ b/CoreZen/Media/Interfaces/MediaInfoController.h
@@ -16,14 +16,8 @@
 // (const AVCodec *)videoCodecHandle;
 - (const void *)videoCodecHandle;
 
-// (const AVCodec *)audioCodecHandle;
-- (const void *)audioCodecHandle;
-
-// (const AVCodecParameters *)videoCodecParamsHandle;
-- (const void *)videoCodecParamsHandle;
-
-// (const AVCodecParameters *)audioCodecParamsHandle;
-- (const void *)audioCodecParamsHandle;
+// (const AVStream *)videoStreamHandle;
+- (const void *)videoStreamHandle;
 
 - (void)terminate;
 

--- a/CoreZen/Media/LibAV/LibAVInfoController.h
+++ b/CoreZen/Media/LibAV/LibAVInfoController.h
@@ -16,7 +16,23 @@
 
 - (instancetype)initWithMediaFile:(ZENMediaFile *)mediaFile;
 
+// ZENMediaInfoController protocol
+
+// (const AVCodec *)videoCodecHandle;
+- (const void *)videoCodecHandle;
+
+// (const AVCodec *)audioCodecHandle;
+- (const void *)audioCodecHandle;
+
+// (const AVCodecParameters *)videoCodecParamsHandle;
+- (const void *)videoCodecParamsHandle;
+
+// (const AVCodecParameters *)audioCodecParamsHandle;
+- (const void *)audioCodecParamsHandle;
+
 - (void)terminate;
+
+- (NSObject<ZENFrameRenderController> *)frameRenderController;
 
 - (NSUInteger)durationMicroseconds;
 

--- a/CoreZen/Media/LibAV/LibAVInfoController.h
+++ b/CoreZen/Media/LibAV/LibAVInfoController.h
@@ -18,6 +18,9 @@
 
 // ZENMediaInfoController protocol
 
+// (AVFormatContext *)formatContextHandle;
+- (void *)formatContextHandle;
+
 // (const AVCodec *)videoCodecHandle;
 - (const void *)videoCodecHandle;
 
@@ -29,6 +32,7 @@
 - (NSObject<ZENFrameRenderController> *)frameRenderController;
 
 - (NSUInteger)durationMicroseconds;
+- (double)durationSeconds;
 
 - (NSUInteger)frameWidth;
 - (NSUInteger)frameHeight;

--- a/CoreZen/Media/LibAV/LibAVInfoController.h
+++ b/CoreZen/Media/LibAV/LibAVInfoController.h
@@ -1,0 +1,32 @@
+//
+//  LibAVInfoController.h
+//  CoreZen
+//
+//  Created by Zach Nelson on 11/8/22.
+//
+
+#import <Foundation/Foundation.h>
+#import <CoreZen/MediaInfoController.h>
+
+@class ZENMediaFile;
+
+@interface ZENLibAVInfoController : NSObject <ZENMediaInfoController>
+
+@property (nonatomic, weak, readonly) ZENMediaFile *mediaFile;
+
+- (instancetype)initWithMediaFile:(ZENMediaFile *)mediaFile;
+
+- (void)terminate;
+
+- (NSUInteger)durationMicroseconds;
+
+- (NSUInteger)frameWidth;
+- (NSUInteger)frameHeight;
+
+- (NSString *)videoCodecName;
+- (NSString *)audioCodecName;
+
+- (NSString *)videoCodecLongName;
+- (NSString *)audioCodecLongName;
+
+@end

--- a/CoreZen/Media/LibAV/LibAVInfoController.h
+++ b/CoreZen/Media/LibAV/LibAVInfoController.h
@@ -21,14 +21,8 @@
 // (const AVCodec *)videoCodecHandle;
 - (const void *)videoCodecHandle;
 
-// (const AVCodec *)audioCodecHandle;
-- (const void *)audioCodecHandle;
-
-// (const AVCodecParameters *)videoCodecParamsHandle;
-- (const void *)videoCodecParamsHandle;
-
-// (const AVCodecParameters *)audioCodecParamsHandle;
-- (const void *)audioCodecParamsHandle;
+// (const AVStream *)videoStreamHandle;
+- (const void *)videoStreamHandle;
 
 - (void)terminate;
 

--- a/CoreZen/Media/LibAV/LibAVInfoController.m
+++ b/CoreZen/Media/LibAV/LibAVInfoController.m
@@ -1,0 +1,188 @@
+//
+//  LibAVInfoController.m
+//  CoreZen
+//
+//  Created by Zach Nelson on 11/8/22.
+//
+
+#import "LibAVInfoController.h"
+#import "MediaFile.h"
+
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdocumentation"
+
+#import <libavcodec/avcodec.h>
+#import <libavformat/avformat.h>
+
+#pragma clang diagnostic pop
+
+void ZENLogAVFindBestStreamError(NSString *filePath, int returnCode, enum AVMediaType mediaType) {
+	NSString *reason = @"Unknown";
+	if (returnCode == AVERROR_STREAM_NOT_FOUND) {
+		NSString *streamType = @"Unknown";
+		if (mediaType == AVMEDIA_TYPE_VIDEO) {
+			streamType = @"AVMEDIA_TYPE_VIDEO";
+		} else if (mediaType == AVMEDIA_TYPE_AUDIO) {
+			streamType = @"AVMEDIA_TYPE_AUDIO";
+		}
+		reason = [NSString stringWithFormat:@"No stream with the requested type could be found (%@)", streamType];
+	}
+	NSLog(@"avformat_find_stream_info(%@, AVMEDIA_TYPE_VIDEO) failed: %@", filePath, reason);
+}
+
+@interface ZENLibAVInfoController ()
+{
+	AVFormatContext *_formatContext;
+
+	// Video
+	AVCodec *_videoCodec;
+	AVCodecParameters *_videoCodecParameters;
+	AVCodecContext *_videoCodecContext;
+
+	// Audio
+	AVCodec *_audioCodec;
+	AVCodecParameters *_audioCodecParameters;
+	AVCodecContext *_audioCodecContext;
+}
+
+@property (nonatomic, weak) ZENMediaFile *mediaFile;
+
+- (void)avInit:(NSString *)filePath;
+
+@end
+
+@implementation ZENLibAVInfoController
+
+- (void)avInit:(NSString *)filePath {
+	_formatContext = avformat_alloc_context();
+	
+	// avformat_open_input() documentation:
+	// Returns 0 on success, a negative AVERROR on failure.
+	int result = avformat_open_input(&_formatContext, filePath.fileSystemRepresentation, NULL, NULL);
+	if (result == 0) {
+
+		// avformat_find_stream_info() documentation:
+		// Returns >=0 if OK, AVERROR_xxx on error
+		result = avformat_find_stream_info(_formatContext, NULL);
+		if (result >= 0) {
+			const AVCodec *constVideoCodec = _videoCodec;
+			const int videoStreamIndex = av_find_best_stream(_formatContext, AVMEDIA_TYPE_VIDEO, -1, -1, &constVideoCodec, 0);
+			if (videoStreamIndex > -1) {
+				// av_find_best_stream() documentation:
+				// If av_find_best_stream returns successfully and decoder_ret (&_videoCodec) is not NULL,
+				// then *decoder_ret (_videoCodec) is guaranteed to be set to a valid AVCodec.
+				
+				_videoCodecParameters = _formatContext->streams[videoStreamIndex]->codecpar;
+
+#if 0
+				// This part only needs to happen if we're going to fetch video frames
+				_videoCodecContext = avcodec_alloc_context3(_videoCodec);
+				result = avcodec_parameters_to_context(_videoCodecContext, _videoCodecParameters);
+				result = avcodec_open2(_videoCodecContext, _videoCodec, NULL);
+#endif
+			} else {
+				ZENLogAVFindBestStreamError(filePath, videoStreamIndex, AVMEDIA_TYPE_VIDEO);
+			}
+			
+			const AVCodec *constAudioCodec = _audioCodec;
+			const int audioStreamIndex = av_find_best_stream(_formatContext, AVMEDIA_TYPE_AUDIO, -1, -1, &constAudioCodec, 0);
+			if (audioStreamIndex > -1) {
+				_audioCodecParameters = _formatContext->streams[audioStreamIndex]->codecpar;
+				
+#if 0
+				// This part only needs to happen if we're going to fetch audio frames
+				_audioCodecContext = avcodec_alloc_context3(_audioCodec);
+				result = avcodec_parameters_to_context(_audioCodecContext, _audioCodecParameters);
+				result = avcodec_open2(_audioCodecContext, _audioCodec, NULL);
+#endif
+			} else {
+				ZENLogAVFindBestStreamError(filePath, audioStreamIndex, AVMEDIA_TYPE_AUDIO);
+			}
+		} else {
+			NSLog(@"avformat_find_stream_info(%@) failed, result: %d", filePath, result);
+		}
+	} else {
+		// avformat_open_input() documentation:
+		// Note that a user-supplied AVFormatContext will be freed on failure.
+		_formatContext = NULL;
+		NSLog(@"avformat_open_input(%@) failed, result: %d", filePath, result);
+	}
+}
+
+- (instancetype)initWithMediaFile:(ZENMediaFile *)mediaFile {
+	self = [super init];
+	if (self) {
+		_mediaFile = mediaFile;
+		
+		NSString *filePath = mediaFile.fileURL.path;
+		[self avInit:filePath];
+	}
+	return self;
+}
+
+- (void)terminate {
+	if (_formatContext) {
+		avformat_close_input(&_formatContext);
+	}
+	if (_videoCodecContext) {
+		avcodec_free_context(&_videoCodecContext);
+	}
+	if (_audioCodecContext) {
+		avcodec_free_context(&_audioCodecContext);
+	}
+}
+
+- (NSUInteger)durationMicroseconds {
+	NSAssert(AV_TIME_BASE == 1000000, @"Expected libav AV_TIME_BASE 1000000 for microseconds, instead = %d", AV_TIME_BASE);
+	return _formatContext->duration;
+}
+
+- (NSUInteger)frameWidth {
+	NSUInteger width = 0;
+	if (_videoCodecParameters) {
+		width = ((NSUInteger)_videoCodecParameters->width);
+	}
+	return width;
+}
+
+- (NSUInteger)frameHeight {
+	NSUInteger height = 0;
+	if (_videoCodecParameters) {
+		height = ((NSUInteger)_videoCodecParameters->height);
+	}
+	return height;
+}
+
+- (NSString *)videoCodecName {
+	NSString *codec = @"Unknown";
+	if (_videoCodec) {
+		codec = [NSString stringWithCString:_videoCodec->name encoding:NSASCIIStringEncoding];
+	}
+	return codec;
+}
+
+- (NSString *)audioCodecName {
+	NSString *codec = @"Unknown";
+	if (_audioCodec) {
+		codec = [NSString stringWithCString:_audioCodec->name encoding:NSASCIIStringEncoding];
+	}
+	return codec;
+}
+
+- (NSString *)videoCodecLongName {
+	NSString *codec = @"Unknown";
+	if (_videoCodec) {
+		codec = [NSString stringWithCString:_videoCodec->long_name encoding:NSASCIIStringEncoding];
+	}
+	return codec;
+}
+
+- (NSString *)audioCodecLongName {
+	NSString *codec = @"Unknown";
+	if (_audioCodec) {
+		codec = [NSString stringWithCString:_audioCodec->long_name encoding:NSASCIIStringEncoding];
+	}
+	return codec;
+}
+
+@end

--- a/CoreZen/Media/LibAV/LibAVInfoController.m
+++ b/CoreZen/Media/LibAV/LibAVInfoController.m
@@ -105,6 +105,10 @@ void ZENLogAVFindBestStreamError(NSString *filePath, int returnCode, enum AVMedi
 	return self;
 }
 
+- (void *)formatContextHandle {
+	return _formatContext;
+}
+
 - (const void *)videoCodecHandle {
 	return _videoCodec;
 }
@@ -132,6 +136,11 @@ void ZENLogAVFindBestStreamError(NSString *filePath, int returnCode, enum AVMedi
 - (NSUInteger)durationMicroseconds {
 	NSAssert(AV_TIME_BASE == 1000000, @"Expected libav AV_TIME_BASE 1000000 for microseconds, instead = %d", AV_TIME_BASE);
 	return _formatContext->duration;
+}
+
+- (double)durationSeconds {
+	NSUInteger us = self.durationMicroseconds;
+	return us / (double)AV_TIME_BASE;
 }
 
 - (NSUInteger)frameWidth {

--- a/CoreZen/Media/LibAV/LibAVRenderController.h
+++ b/CoreZen/Media/LibAV/LibAVRenderController.h
@@ -1,0 +1,22 @@
+//
+//  LibAVRenderController.h
+//  CoreZen
+//
+//  Created by Zach Nelson on 11/8/22.
+//
+
+#import <Foundation/Foundation.h>
+#import <CoreZen/FrameRenderController.h>
+
+@class ZENMediaFile;
+@class ZENLibAVInfoController;
+
+@interface ZENLibAVRenderController : NSObject <ZENFrameRenderController>
+
+@property (nonatomic, weak, readonly) ZENMediaFile *mediaFile;
+
+- (instancetype)initWithInfoController:(ZENLibAVInfoController *)infoController;
+
+- (void)terminate;
+
+@end

--- a/CoreZen/Media/LibAV/LibAVRenderController.h
+++ b/CoreZen/Media/LibAV/LibAVRenderController.h
@@ -17,6 +17,12 @@
 
 - (instancetype)initWithInfoController:(ZENLibAVInfoController *)infoController;
 
+// ZENFrameRenderController protocol
+
 - (void)terminate;
+
+- (void)renderFrame:(ZENRenderedFrame *)frame
+			   size:(NSSize)size
+		 completion:(ZENFrameRendererResultsBlock)completion;
 
 @end

--- a/CoreZen/Media/LibAV/LibAVRenderController.m
+++ b/CoreZen/Media/LibAV/LibAVRenderController.m
@@ -8,12 +8,17 @@
 #import "LibAVRenderController.h"
 #import "LibAVInfoController.h"
 #import "MediaFile.h"
+#import "FrameRenderer.h"
+
+@import Cocoa;
 
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wdocumentation"
 
 #import <libavcodec/avcodec.h>
 #import <libavformat/avformat.h>
+#import <libavutil/imgutils.h>
+#import <libswscale/swscale.h>
 
 #pragma clang diagnostic pop
 
@@ -23,8 +28,20 @@
 }
 
 @property (nonatomic, weak) ZENMediaFile *mediaFile;
+@property (nonatomic, weak) ZENLibAVInfoController *infoController;
 
-- (void)avInitWithCodec:(const AVCodec *)codec stream:(const AVStream *)stream;
+- (void)avInitWithCodec:(const AVCodec *)codec
+				 stream:(const AVStream *)stream;
+
+- (BOOL)renderRawFrame:(AVFrame *)frame
+		 formatContext:(AVFormatContext *)formatContext
+				stream:(const AVStream *)stream
+			 timestamp:(int64_t)timestamp;
+
+- (BOOL)resizeRawFrame:(AVFrame **)frame
+					   size:(NSSize)size;
+
+- (NSImage *)convertRawFrameToImage:(AVFrame *)frame;
 
 @end
 
@@ -53,6 +70,7 @@
 	self = [super init];
 	if (self) {
 		_mediaFile = infoController.mediaFile;
+		_infoController = infoController;
 		
 		const AVCodec *videoCodec = infoController.videoCodecHandle;
 		const AVStream *videoStream = infoController.videoStreamHandle;
@@ -66,6 +84,179 @@
 	if (_codecContext) {
 		avcodec_free_context(&_codecContext);
 	}
+}
+
+- (BOOL)renderRawFrame:(AVFrame *)frame
+		 formatContext:(AVFormatContext *)formatContext
+				stream:(const AVStream *)stream
+			 timestamp:(int64_t)timestamp {
+	
+	avcodec_flush_buffers(_codecContext);
+	
+	int streamIndex = stream->index;
+	
+	int result = av_seek_frame(formatContext, streamIndex, timestamp, AVSEEK_FLAG_BACKWARD);
+	if (result < 0) {
+		NSLog(@"av_seek_frame failed: %d", result);
+		return FALSE;
+	}
+	
+	avcodec_flush_buffers(_codecContext);
+	
+	AVPacket packet;
+	
+	while (av_read_frame(formatContext, &packet) >= 0) {
+		@try {
+			if (packet.stream_index == streamIndex) {
+				result = avcodec_send_packet(_codecContext, &packet);
+				if (result < 0) {
+					NSLog(@"avcodec_send_packet failed: %d", result);
+					break;
+				}
+				
+				result = avcodec_receive_frame(_codecContext, frame);
+				if (result < 0) {
+					if (result == AVERROR(EAGAIN)) {
+						NSLog(@"avcodec_receive_frame failed: EAGAIN (input not ready, retrying)");
+						continue;
+					} else {
+						NSLog(@"avcodec_receive_frame failed: %d", result);
+						break;
+					}
+				}
+			}
+		} @catch (NSException *exception) {
+			NSLog(@"Exception caught during decode: %@", exception);
+		} @finally {
+			av_packet_unref(&packet);
+		}
+	}
+	
+	return (result >= 0);
+}
+
+- (BOOL)resizeRawFrame:(AVFrame **)frame
+				  size:(NSSize)size {
+	
+	BOOL success = NO;
+	AVFrame *rgbFrame = av_frame_alloc();
+	
+	AVFrame *sourceFrame = *frame;
+	
+	// At the end, one frame will get freed and the other returned. If conversion
+	// is successful, we'll update this to point to sourceFrame.
+	AVFrame *frameToFree = rgbFrame;
+	
+	rgbFrame->width = size.width;
+	rgbFrame->height = size.height;
+	rgbFrame->format = AV_PIX_FMT_RGBA;
+	
+	int bufferSize = av_image_get_buffer_size(rgbFrame->format, rgbFrame->width, rgbFrame->height, 1);
+	
+	uint8_t *rgbBuffer = av_malloc(bufferSize);
+	
+	int result = av_image_fill_arrays(rgbFrame->data, rgbFrame->linesize, rgbBuffer, rgbFrame->format, rgbFrame->width, rgbFrame->height, 1);
+	
+	av_free(rgbBuffer);
+	
+	if (result >= 0) {
+		// Cast to get around rules about adding `const` more than one level deep: https://stackoverflow.com/a/5055789
+		const uint8_t * const * frameData = (const uint8_t * const *)sourceFrame->data;
+		
+		// Create scale context
+		struct SwsContext *scaleContext = sws_getContext(_codecContext->width, _codecContext->height, _codecContext->pix_fmt, rgbFrame->width, rgbFrame->height, rgbFrame->format, SWS_BILINEAR, NULL, NULL, NULL);
+		
+		// Scale and convert colorspace to new frame
+		result = sws_scale(scaleContext, frameData, sourceFrame->linesize, 0, _codecContext->height, rgbFrame->data, rgbFrame->linesize);
+		
+		// Clean up scale context
+		sws_freeContext(scaleContext);
+		
+		if (result >= 0) {
+			frameToFree = sourceFrame;
+			*frame = rgbFrame;
+			success = YES;
+
+		} else {
+			NSLog(@"sws_scale failed: %d", result);
+		}
+	} else {
+		NSLog(@"av_image_fill_arrays failed: %d", result);
+	}
+	
+	av_frame_free(&frameToFree);
+	
+	return success;
+}
+
+- (NSImage *)convertRawFrameToImage:(AVFrame *)frame {
+	
+	CGColorSpaceRef colorSpace = CGColorSpaceCreateDeviceRGB();
+	
+	void *frameData = frame->data[0];
+	size_t width = frame->width;
+	size_t height = frame->height;
+	
+	CGContextRef bitmapContext = CGBitmapContextCreate(frameData, width, height, 8, width * 4, colorSpace, kCGImageAlphaPremultipliedLast);
+	
+	CGImageRef bitmap = CGBitmapContextCreateImage(bitmapContext);
+	
+	NSImage *image = [[NSImage alloc] initWithCGImage:bitmap size:NSZeroSize];
+	
+	CFRelease(colorSpace);
+	CFRelease(bitmapContext);
+	CFRelease(bitmap);
+	
+	return image;
+}
+
+- (void)renderFrame:(ZENRenderedFrame *)frame
+			   size:(NSSize)size
+		 completion:(ZENFrameRendererResultsBlock)completion {
+	
+	NSObject<ZENMediaInfoController> *infoController = self.infoController;
+	
+	double durationSeconds = infoController.durationSeconds;
+	
+	// Calling code fills in either .requestedSeconds or .requestedPercentage; fill in the other
+	if (frame.requestedSeconds > frame.requestedPercentage) {
+		// seconds -> percentage
+		frame.requestedPercentage = frame.requestedSeconds / durationSeconds;
+	} else if (frame.requestedPercentage > frame.requestedSeconds) {
+		// percentage -> seconds
+		frame.requestedSeconds = durationSeconds * frame.requestedPercentage;
+	}
+	
+	AVFormatContext *formatContext = infoController.formatContextHandle;
+	const AVStream *stream = infoController.videoStreamHandle;
+	
+	int64_t durationTicks = formatContext->duration;
+	
+	// Get duration in terms of the video stream time base (instead of overall libav time base)
+	int64_t duration = av_rescale_q(durationTicks, AV_TIME_BASE_Q, stream->time_base);
+	int64_t frameTimestamp = duration * frame.requestedPercentage;
+	
+	frame.requestedTimestamp = frameTimestamp;
+	
+	AVFrame *rawFrame = av_frame_alloc();
+	
+	// Render the frame at timestamp from media file
+	if ([self renderRawFrame:rawFrame formatContext:formatContext stream:stream timestamp:frameTimestamp]) {
+		
+		frame.actualTimestamp = rawFrame->best_effort_timestamp;
+		frame.actualPercentage = frame.actualTimestamp / (double)durationTicks;
+		frame.actualSeconds = frame.actualPercentage * durationSeconds;
+		
+		// Resize the frame to desired size, convert to RGB
+		if ([self resizeRawFrame:&rawFrame size:size]) {
+			
+			frame.image = [self convertRawFrameToImage:rawFrame];
+		}
+	}
+	
+	av_frame_free(&rawFrame);
+	
+	completion(frame);
 }
 
 @end

--- a/CoreZen/Media/LibAV/LibAVRenderController.m
+++ b/CoreZen/Media/LibAV/LibAVRenderController.m
@@ -1,0 +1,64 @@
+//
+//  LibAVRenderController.m
+//  CoreZen
+//
+//  Created by Zach Nelson on 11/8/22.
+//
+
+#import "LibAVRenderController.h"
+#import "LibAVInfoController.h"
+#import "MediaFile.h"
+
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdocumentation"
+
+#import <libavcodec/avcodec.h>
+#import <libavformat/avformat.h>
+
+#pragma clang diagnostic pop
+
+@interface ZENLibAVRenderController ()
+{
+	AVCodecContext *_videoCodecContext;
+	AVCodecContext *_audioCodecContext;
+}
+
+@property (nonatomic, weak) ZENMediaFile *mediaFile;
+
+- (void)avInit:(ZENLibAVInfoController *)infoController;
+
+@end
+
+@implementation ZENLibAVRenderController
+
+- (void)avInit:(ZENLibAVInfoController *)infoController {
+	const AVCodec *videoCodec = infoController.videoCodecHandle;
+	const AVCodecParameters *videoCodecParams = infoController.videoCodecParamsHandle;
+	
+	const AVCodec *audioCodec = infoController.audioCodecHandle;
+	const AVCodecParameters *audioCodecParams = infoController.audioCodecParamsHandle;
+	
+	_videoCodecContext = avcodec_alloc_context3(videoCodec);
+	int result = avcodec_parameters_to_context(_videoCodecContext, videoCodecParams);
+	result = avcodec_open2(_videoCodecContext, videoCodec, NULL);
+	
+	_audioCodecContext = avcodec_alloc_context3(audioCodec);
+	result = avcodec_parameters_to_context(_audioCodecContext, audioCodecParams);
+	result = avcodec_open2(_audioCodecContext, audioCodec, NULL);
+}
+
+- (instancetype)initWithInfoController:(ZENLibAVInfoController *)infoController {
+	self = [super init];
+	if (self) {
+		_mediaFile = infoController.mediaFile;
+		
+		[self avInit:infoController];
+	}
+	return self;
+}
+
+- (void)terminate {
+	
+}
+
+@end

--- a/CoreZen/Media/MediaFile.h
+++ b/CoreZen/Media/MediaFile.h
@@ -7,11 +7,15 @@
 
 #import <Foundation/Foundation.h>
 
+@class ZENFrameRenderer;
+
 @interface ZENMediaFile : NSObject
 
 @property (nonatomic, strong, readonly) NSURL *fileURL;
 
 + (instancetype)mediaFileWithURL:(NSURL*)url;
+
+- (ZENFrameRenderer *)frameRenderer;
 
 - (NSUInteger)durationMicroseconds;
 

--- a/CoreZen/Media/MediaFile.m
+++ b/CoreZen/Media/MediaFile.m
@@ -29,8 +29,8 @@
 }
 
 + (instancetype)mediaFileWithURL:(NSURL *)url {
-	ZENMediaFile *mf = [[ZENMediaFile alloc] initWithURL:url];
-	return mf;
+	ZENMediaFile *mediaFile = [[ZENMediaFile alloc] initWithURL:url];
+	return mediaFile;
 }
 
 - (ZENFrameRenderer *)frameRenderer {

--- a/CoreZen/Media/MediaFile.m
+++ b/CoreZen/Media/MediaFile.m
@@ -7,6 +7,7 @@
 
 #import "MediaFile+Private.h"
 #import "LibAVInfoController.h"
+#import "FrameRenderer.h"
 
 @interface ZENMediaFile ()
 
@@ -30,6 +31,12 @@
 + (instancetype)mediaFileWithURL:(NSURL *)url {
 	ZENMediaFile *mf = [[ZENMediaFile alloc] initWithURL:url];
 	return mf;
+}
+
+- (ZENFrameRenderer *)frameRenderer {
+	NSObject<ZENFrameRenderController> *controller = self.mediaInfoController.frameRenderController;
+	ZENFrameRenderer *frameRenderer = [[ZENFrameRenderer alloc] initWithController:controller];
+	return frameRenderer;
 }
 
 - (NSUInteger)durationMicroseconds {

--- a/CoreZen/Media/MediaFile.m
+++ b/CoreZen/Media/MediaFile.m
@@ -5,198 +5,59 @@
 //  Created by Zach Nelson on 3/18/22.
 //
 
-#import "MediaFile.h"
-
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wdocumentation"
-
-#import <libavcodec/avcodec.h>
-#import <libavformat/avformat.h>
-
-#pragma clang diagnostic pop
-
-void ZENLogAVFindBestStreamError(NSString *filePath, int returnCode, enum AVMediaType mediaType) {
-	NSString *reason = @"Unknown";
-	if (returnCode == AVERROR_STREAM_NOT_FOUND) {
-		NSString *streamType = @"Unknown";
-		if (mediaType == AVMEDIA_TYPE_VIDEO) {
-			streamType = @"AVMEDIA_TYPE_VIDEO";
-		} else if (mediaType == AVMEDIA_TYPE_AUDIO) {
-			streamType = @"AVMEDIA_TYPE_AUDIO";
-		}
-		reason = [NSString stringWithFormat:@"No stream with the requested type could be found (%@)", streamType];
-	}
-	NSLog(@"avformat_find_stream_info(%@, AVMEDIA_TYPE_VIDEO) failed: %@", filePath, reason);
-}
+#import "MediaFile+Private.h"
+#import "LibAVInfoController.h"
 
 @interface ZENMediaFile ()
-{
-	AVFormatContext *_formatContext;
-	
-	// Video
-	AVCodec *_videoCodec;
-	AVCodecParameters *_videoCodecParameters;
-	AVCodecContext *_videoCodecContext;
-	
-	// Audio
-	AVCodec *_audioCodec;
-	AVCodecParameters *_audioCodecParameters;
-	AVCodecContext *_audioCodecContext;
-}
 
 @property (nonatomic, strong) NSURL *fileURL;
 
 - (instancetype)initWithURL:(NSURL *)url;
-- (void)avInit:(NSString *)filePath;
 
 @end
 
 @implementation ZENMediaFile
 
-- (void)dealloc {
-	if (_formatContext) {
-		avformat_close_input(&_formatContext);
-	}
-	if (_videoCodecContext) {
-		avcodec_free_context(&_videoCodecContext);
-	}
-	if (_audioCodecContext) {
-		avcodec_free_context(&_audioCodecContext);
-	}
-}
-
-- (void)avInit:(NSString *)filePath {
-	_formatContext = avformat_alloc_context();
-	
-	// avformat_open_input() documentation:
-	// Returns 0 on success, a negative AVERROR on failure.
-	int result = avformat_open_input(&_formatContext, filePath.fileSystemRepresentation, NULL, NULL);
-	if (result == 0) {
-
-		// avformat_find_stream_info() documentation:
-		// Returns >=0 if OK, AVERROR_xxx on error
-		result = avformat_find_stream_info(_formatContext, NULL);
-		if (result >= 0) {
-			const AVCodec *constVideoCodec = _videoCodec;
-			const int videoStreamIndex = av_find_best_stream(_formatContext, AVMEDIA_TYPE_VIDEO, -1, -1, &constVideoCodec, 0);
-			if (videoStreamIndex > -1) {
-				// av_find_best_stream() documentation:
-				// If av_find_best_stream returns successfully and decoder_ret (&_videoCodec) is not NULL,
-				// then *decoder_ret (_videoCodec) is guaranteed to be set to a valid AVCodec.
-				
-				_videoCodecParameters = _formatContext->streams[videoStreamIndex]->codecpar;
-
-#if 0
-				// This part only needs to happen if we're going to fetch video frames
-				_videoCodecContext = avcodec_alloc_context3(_videoCodec);
-				result = avcodec_parameters_to_context(_videoCodecContext, _videoCodecParameters);
-				result = avcodec_open2(_videoCodecContext, _videoCodec, NULL);
-#endif
-			} else {
-				ZENLogAVFindBestStreamError(filePath, videoStreamIndex, AVMEDIA_TYPE_VIDEO);
-			}
-			
-			const AVCodec *constAudioCodec = _audioCodec;
-			const int audioStreamIndex = av_find_best_stream(_formatContext, AVMEDIA_TYPE_AUDIO, -1, -1, &constAudioCodec, 0);
-			if (audioStreamIndex > -1) {
-				_audioCodecParameters = _formatContext->streams[audioStreamIndex]->codecpar;
-				
-#if 0
-				// This part only needs to happen if we're going to fetch audio frames
-				_audioCodecContext = avcodec_alloc_context3(_audioCodec);
-				result = avcodec_parameters_to_context(_audioCodecContext, _audioCodecParameters);
-				result = avcodec_open2(_audioCodecContext, _audioCodec, NULL);
-#endif
-			} else {
-				ZENLogAVFindBestStreamError(filePath, audioStreamIndex, AVMEDIA_TYPE_AUDIO);
-			}
-		} else {
-			NSLog(@"avformat_find_stream_info(%@) failed, result: %d", filePath, result);
-		}
-	} else {
-		// avformat_open_input() documentation:
-		// Note that a user-supplied AVFormatContext will be freed on failure.
-		_formatContext = NULL;
-		NSLog(@"avformat_open_input(%@) failed, result: %d", filePath, result);
-	}
-}
-
 - (instancetype)initWithURL:(NSURL *)url {
 	self = [super init];
 	if (self) {
-		_formatContext = NULL;
-		
-		_videoCodec = NULL;
-		_videoCodecParameters = NULL;
-		_videoCodecContext = NULL;
-		
-		_audioCodec = NULL;
-		_audioCodecParameters = NULL;
-		_audioCodecContext = NULL;
-		
 		_fileURL = url;
-		
-		[self avInit:self.fileURL.path];
+		_mediaInfoController = [[ZENLibAVInfoController alloc] initWithMediaFile:self];
 	}
 	return self;
 }
 
 + (instancetype)mediaFileWithURL:(NSURL *)url {
-	ZENMediaFile *wrapper = [[ZENMediaFile alloc] initWithURL:url];
-	return wrapper;
+	ZENMediaFile *mf = [[ZENMediaFile alloc] initWithURL:url];
+	return mf;
 }
 
 - (NSUInteger)durationMicroseconds {
-	NSAssert(AV_TIME_BASE == 1000000, @"Expected libav AV_TIME_BASE 1000000 for microseconds, instead = %d", AV_TIME_BASE);
-	return _formatContext->duration;
+	return self.mediaInfoController.durationMicroseconds;
 }
 
 - (NSUInteger)frameWidth {
-	NSUInteger width = 0;
-	if (_videoCodecParameters) {
-		width = ((NSUInteger)_videoCodecParameters->width);
-	}
-	return width;
+	return self.mediaInfoController.frameWidth;
 }
 
 - (NSUInteger)frameHeight {
-	NSUInteger height = 0;
-	if (_videoCodecParameters) {
-		height = ((NSUInteger)_videoCodecParameters->height);
-	}
-	return height;
+	return self.mediaInfoController.frameHeight;
 }
 
 - (NSString *)videoCodecName {
-	NSString *codec = @"Unknown";
-	if (_videoCodec) {
-		codec = [NSString stringWithCString:_videoCodec->name encoding:NSASCIIStringEncoding];
-	}
-	return codec;
+	return self.mediaInfoController.videoCodecName;
 }
 
 - (NSString *)audioCodecName {
-	NSString *codec = @"Unknown";
-	if (_audioCodec) {
-		codec = [NSString stringWithCString:_audioCodec->name encoding:NSASCIIStringEncoding];
-	}
-	return codec;
+	return self.mediaInfoController.audioCodecName;
 }
 
 - (NSString *)videoCodecLongName {
-	NSString *codec = @"Unknown";
-	if (_videoCodec) {
-		codec = [NSString stringWithCString:_videoCodec->long_name encoding:NSASCIIStringEncoding];
-	}
-	return codec;
+	return self.mediaInfoController.videoCodecLongName;
 }
 
 - (NSString *)audioCodecLongName {
-	NSString *codec = @"Unknown";
-	if (_audioCodec) {
-		codec = [NSString stringWithCString:_audioCodec->long_name encoding:NSASCIIStringEncoding];
-	}
-	return codec;
+	return self.mediaInfoController.audioCodecLongName;
 }
 
 @end


### PR DESCRIPTION
This is a checkpoint on work to return a ZENFrameRenderer from ZENMediaFile. The MediaInfoController creates and owns the FrameRenderController, because they both share the same libav context handles. No threading yet, just untested proof of concept code.