### PR TITLE
Added libav serial render queue

### DIFF
--- a/CoreZen/Database/DatabaseQueue.m
+++ b/CoreZen/Database/DatabaseQueue.m
@@ -11,7 +11,7 @@
 
 #import <stdatomic.h>
 
-#define RETURN_IF_TERMINATING if (atomic_load(&self->_terminating)) { return; }
+#define RETURN_IF_TERMINATING if (atomic_load(&_terminating)) { return; }
 #define RETURN_IF_TERMINATED if (self->_terminated) { return; }
 
 @interface ZENDatabaseQueue ()
@@ -47,15 +47,15 @@
 		NSLog(@"Database in memory");
 		_databaseURL = nil;
 		
-		static NSUInteger cacheID = 0;
-		NSString *databaseID = [NSString stringWithFormat:@"corezen-mem-db-%lu", cacheID];
+		static atomic_uint_fast64_t nextIdentifier = 0;
+		uint64_t cacheID = atomic_fetch_add(&nextIdentifier, 1);
+
+		NSString *databaseID = [NSString stringWithFormat:@"corezen-mem-db-%llu", cacheID];
 		
 		_databaseKey = [NSString stringWithFormat:@"file:%@?mode=memory&cache=shared", databaseID];
 	
-		NSString *queueLabel = [NSString stringWithFormat:@"ZENDatabaseQueue-InMemory-%lu", cacheID];
+		NSString *queueLabel = [NSString stringWithFormat:@"ZENDatabaseQueue-InMemory-%llu", cacheID];
 		[self internalInit:queueLabel];
-		
-		cacheID++;
 	}
 	return self;
 }

--- a/CoreZen/Media/FrameRenderer.m
+++ b/CoreZen/Media/FrameRenderer.m
@@ -11,10 +11,6 @@
 @implementation ZENRenderedFrame
 @end
 
-@interface ZENFrameRenderer ()
-
-@end
-
 @implementation ZENFrameRenderer
 
 - (instancetype)initWithController:(NSObject<ZENFrameRenderController> *)controller {

--- a/CoreZen/Media/Interfaces/FrameRenderController.h
+++ b/CoreZen/Media/Interfaces/FrameRenderController.h
@@ -12,7 +12,7 @@
 
 - (void)terminate;
 
-- (void)renderFrame:(ZENRenderedFrame *)frame
+- (void)renderFrame:(ZENRenderedFrame *)renderedFrame
 			   size:(NSSize)size
 		 completion:(ZENFrameRendererResultsBlock)completion;
 

--- a/CoreZen/Media/Interfaces/MediaInfoController.h
+++ b/CoreZen/Media/Interfaces/MediaInfoController.h
@@ -6,10 +6,11 @@
 //
 
 #import <Foundation/Foundation.h>
+#import <CoreZen/Identifiable.h>
 
 @protocol ZENFrameRenderController;
 
-@protocol ZENMediaInfoController <NSObject>
+@protocol ZENMediaInfoController <NSObject, ZENIdentifiable>
 
 - (NSObject<ZENFrameRenderController> *)frameRenderController;
 

--- a/CoreZen/Media/LibAV/LibAVInfoController.m
+++ b/CoreZen/Media/LibAV/LibAVInfoController.m
@@ -9,6 +9,8 @@
 #import "LibAVRenderController.h"
 #import "MediaFile.h"
 
+#import <stdatomic.h>
+
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wdocumentation"
 
@@ -54,6 +56,8 @@ void ZENLogAVFindBestStreamError(NSString *filePath, int returnCode, enum AVMedi
 
 @implementation ZENLibAVInfoController
 
+@synthesize identifier=_identifier;
+
 - (void)avInit:(NSString *)filePath {
 	_formatContext = avformat_alloc_context();
 	
@@ -98,6 +102,9 @@ void ZENLogAVFindBestStreamError(NSString *filePath, int returnCode, enum AVMedi
 	self = [super init];
 	if (self) {
 		_mediaFile = mediaFile;
+		
+		static atomic_uint_fast64_t nextIdentifier = 0;
+		_identifier = atomic_fetch_add(&nextIdentifier, 1);
 		
 		NSString *filePath = mediaFile.fileURL.path;
 		[self avInit:filePath];

--- a/CoreZen/Media/LibAV/LibAVRenderController.h
+++ b/CoreZen/Media/LibAV/LibAVRenderController.h
@@ -21,7 +21,7 @@
 
 - (void)terminate;
 
-- (void)renderFrame:(ZENRenderedFrame *)frame
+- (void)renderFrame:(ZENRenderedFrame *)renderedFrame
 			   size:(NSSize)size
 		 completion:(ZENFrameRendererResultsBlock)completion;
 

--- a/CoreZen/Media/MPV/MPVFunctions.h
+++ b/CoreZen/Media/MPV/MPVFunctions.h
@@ -20,7 +20,5 @@ BOOL zen_mpv_compare_strings(const char* const one, const char* const two);
 void zen_mpv_init_pthread_mutex_cond(pthread_mutex_t* mutex, pthread_cond_t* cond);
 void zen_mpv_destroy_pthread_mutex_cond(pthread_mutex_t* mutex, pthread_cond_t* cond);
 
-uint64_t zen_mpv_next_observer_identifier(void);
-
 void *zen_mpv_get_opengl_proc_address(void *ctx, const char *name);
 

--- a/CoreZen/Media/MPV/MPVFunctions.m
+++ b/CoreZen/Media/MPV/MPVFunctions.m
@@ -9,8 +9,6 @@
 
 @import Darwin.POSIX.pthread;
 
-#import <stdatomic.h>
-
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wdocumentation"
 
@@ -59,11 +57,6 @@ void zen_mpv_init_pthread_mutex_cond(pthread_mutex_t* mutex, pthread_cond_t* con
 void zen_mpv_destroy_pthread_mutex_cond(pthread_mutex_t* mutex, pthread_cond_t* cond) {
 	pthread_mutex_destroy(mutex);
 	pthread_cond_destroy(cond);
-}
-
-uint64_t zen_mpv_next_observer_identifier(void) {
-	static atomic_uint_fast64_t nextIdentifier = 1;
-	return atomic_fetch_add(&nextIdentifier, 1);
 }
 
 void *zen_mpv_get_opengl_proc_address(void *ctx, const char *name) {

--- a/CoreZen/Media/MPV/MPVPlayerController.m
+++ b/CoreZen/Media/MPV/MPVPlayerController.m
@@ -10,6 +10,8 @@
 #import "MPVConstants.h"
 #import "MediaPlayer+Private.h"
 
+#import <stdatomic.h>
+
 @import Darwin.POSIX.pthread;
 
 #pragma clang diagnostic push
@@ -62,7 +64,9 @@ static void zen_mpv_wakeup(void *ctx);
 	if (self) {
 		_player = player;
 		
-		_identifier = zen_mpv_next_observer_identifier();
+		static atomic_uint_fast64_t nextIdentifier = 1;
+		_identifier = atomic_fetch_add(&nextIdentifier, 1);
+		
 		_terminated = NO;
 		
 		// Initialize mutex and condition variable

--- a/CoreZen/Media/MPV/MPVPlayerController.m
+++ b/CoreZen/Media/MPV/MPVPlayerController.m
@@ -70,7 +70,7 @@ static void zen_mpv_wakeup(void *ctx);
 		
 		// Initialize MPV player event serial queue
 		dispatch_queue_attr_t qos = dispatch_queue_attr_make_with_qos_class(DISPATCH_QUEUE_SERIAL, QOS_CLASS_USER_INITIATED, 0);
-		_eventQueue = dispatch_queue_create("com.zdnelson.CoreZen.mpv-player", qos);
+		_eventQueue = dispatch_queue_create("ZENMediaPlayer.mpv-player", qos);
 		
 		// Create MPV handle (initialization happens after configuration)
 		_mpvHandle = mpv_create();
@@ -121,6 +121,8 @@ static void zen_mpv_wakeup(void *ctx);
 - (void)terminate {
 	mpv_unobserve_property(_mpvHandle, self.identifier);
 	
+	NSLog(@"Terminating mpv player queue...");
+	
 	// Send a mpv quit command, which will trigger MPV_EVENT_SHUTDOWN
 	[self mpvSimpleCommand:kMPVCommand_quit];
 
@@ -130,6 +132,8 @@ static void zen_mpv_wakeup(void *ctx);
 		pthread_cond_wait(&_playerCondition, &_playerMutex);
 	}
 	pthread_mutex_unlock(&_playerMutex);
+	
+	NSLog(@"Finished terminating mpv player queue");
 	
 	// Clean up mutex and condition variable
 	zen_mpv_destroy_pthread_mutex_cond(&_playerMutex, &_playerCondition);

--- a/CoreZen/Media/MPV/MPVRenderController.m
+++ b/CoreZen/Media/MPV/MPVRenderController.m
@@ -63,7 +63,7 @@ static void zen_mpv_render_context_update(void *ctx);
 		zen_mpv_init_pthread_mutex_cond(&_renderMutex, &_renderCondition);
 		
 		dispatch_queue_attr_t qos = dispatch_queue_attr_make_with_qos_class(DISPATCH_QUEUE_SERIAL, QOS_CLASS_USER_INTERACTIVE, 0);
-		_renderQueue = dispatch_queue_create("com.zdnelson.CoreZen.mpv-render", qos);
+		_renderQueue = dispatch_queue_create("ZENMediaPlayer.mpv-render", qos);
 		
 		NSSize playerViewSize = playerView.frame.size;
 		_mpvFBO = (mpv_opengl_fbo) { .fbo = 1, .w = playerViewSize.width, .h = playerViewSize.height };
@@ -119,6 +119,8 @@ static void zen_mpv_render_context_update(void *ctx);
 - (void)destroyRenderContext {
 	mpv_render_context_set_update_callback(_mpvRenderContext, NULL, NULL);
 	
+	NSLog(@"Terminating mpv render queue...");
+	
 	pthread_mutex_lock(&_renderMutex);
 	
 	_terminated = YES;
@@ -127,6 +129,8 @@ static void zen_mpv_render_context_update(void *ctx);
 	pthread_mutex_unlock(&_renderMutex);
 	
 	dispatch_sync(_renderQueue, ^{});
+	
+	NSLog(@"Finished terminating mpv render queue");
 	
 	zen_mpv_destroy_pthread_mutex_cond(&_renderMutex, &_renderCondition);
 	

--- a/CoreZen/Media/MediaFile.h
+++ b/CoreZen/Media/MediaFile.h
@@ -6,10 +6,11 @@
 //
 
 #import <Foundation/Foundation.h>
+#import <CoreZen/Identifiable.h>
 
 @class ZENFrameRenderer;
 
-@interface ZENMediaFile : NSObject
+@interface ZENMediaFile : NSObject <ZENIdentifiable>
 
 @property (nonatomic, strong, readonly) NSURL *fileURL;
 

--- a/CoreZen/Media/MediaFile.h
+++ b/CoreZen/Media/MediaFile.h
@@ -16,6 +16,13 @@
 
 + (instancetype)mediaFileWithURL:(NSURL*)url;
 
+// Terminate frame renderer (and frame render controller) if one was created,
+// then terminate media file format context
+- (void)terminateMediaFile;
+
+// Call before application terminates to terminate all ZENMediaFile instances
++ (void)terminateAllMediaFiles;
+
 - (ZENFrameRenderer *)frameRenderer;
 
 - (NSUInteger)durationMicroseconds;

--- a/CoreZen/Media/MediaFile.m
+++ b/CoreZen/Media/MediaFile.m
@@ -19,11 +19,14 @@
 
 @implementation ZENMediaFile
 
+@synthesize identifier=_identifier;
+
 - (instancetype)initWithURL:(NSURL *)url {
 	self = [super init];
 	if (self) {
 		_fileURL = url;
 		_mediaInfoController = [[ZENLibAVInfoController alloc] initWithMediaFile:self];
+		_identifier = _mediaInfoController.identifier;
 	}
 	return self;
 }


### PR DESCRIPTION
Added a render queue for FrameRenderer. It needs to be a serial queue because the seek state of the AVFormatContext changes during rendering. Termination is identical to database queue. 