### PR TITLE
Click playback slider to scrub

### DIFF
--- a/CoreZen.xcodeproj/project.pbxproj
+++ b/CoreZen.xcodeproj/project.pbxproj
@@ -49,6 +49,8 @@
 		532CA236291B1F73008FA673 /* FrameRenderController.h in Headers */ = {isa = PBXBuildFile; fileRef = 532CA22F291B1B85008FA673 /* FrameRenderController.h */; };
 		532CA237291C5C65008FA673 /* libswscale.6.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = 539A15B128DA2099007D001A /* libswscale.6.dylib */; };
 		532CA23D291D8152008FA673 /* FrameRendererTypes.h in Headers */ = {isa = PBXBuildFile; fileRef = 532CA23C291D8152008FA673 /* FrameRendererTypes.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		532CA240291ED1F9008FA673 /* MediaPlayerSliderCell.h in Headers */ = {isa = PBXBuildFile; fileRef = 532CA23E291ED1F9008FA673 /* MediaPlayerSliderCell.h */; };
+		532CA241291ED1F9008FA673 /* MediaPlayerSliderCell.m in Sources */ = {isa = PBXBuildFile; fileRef = 532CA23F291ED1F9008FA673 /* MediaPlayerSliderCell.m */; };
 		533005DE28F784B600E59E1D /* ZENMediaPlayerControlsView.xib in Resources */ = {isa = PBXBuildFile; fileRef = 533005DD28F784B600E59E1D /* ZENMediaPlayerControlsView.xib */; };
 		5350F8A42886020500F8CA68 /* DatabaseTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 5350F8A32886020500F8CA68 /* DatabaseTests.m */; };
 		5350F8B42886074F00F8CA68 /* ObjectCacheTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 5350F8B32886074F00F8CA68 /* ObjectCacheTests.m */; };
@@ -346,6 +348,8 @@
 		532CA232291B1E96008FA673 /* LibAVRenderController.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = LibAVRenderController.h; sourceTree = "<group>"; };
 		532CA233291B1E96008FA673 /* LibAVRenderController.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = LibAVRenderController.m; sourceTree = "<group>"; };
 		532CA23C291D8152008FA673 /* FrameRendererTypes.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = FrameRendererTypes.h; path = CoreZen/Media/FrameRendererTypes.h; sourceTree = SOURCE_ROOT; };
+		532CA23E291ED1F9008FA673 /* MediaPlayerSliderCell.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MediaPlayerSliderCell.h; sourceTree = "<group>"; };
+		532CA23F291ED1F9008FA673 /* MediaPlayerSliderCell.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MediaPlayerSliderCell.m; sourceTree = "<group>"; };
 		533005DD28F784B600E59E1D /* ZENMediaPlayerControlsView.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = ZENMediaPlayerControlsView.xib; sourceTree = "<group>"; };
 		5350F8A32886020500F8CA68 /* DatabaseTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = DatabaseTests.m; sourceTree = "<group>"; };
 		5350F8B32886074F00F8CA68 /* ObjectCacheTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = ObjectCacheTests.m; sourceTree = "<group>"; };
@@ -773,6 +777,8 @@
 				5386706928BFE16300FB15EB /* MediaPlayerControlsView.m */,
 				531673642909C1DD003FB35A /* MediaPlayerCTIView.h */,
 				531673652909C1DD003FB35A /* MediaPlayerCTIView.m */,
+				532CA23E291ED1F9008FA673 /* MediaPlayerSliderCell.h */,
+				532CA23F291ED1F9008FA673 /* MediaPlayerSliderCell.m */,
 			);
 			path = Views;
 			sourceTree = "<group>";
@@ -1229,6 +1235,7 @@
 				538E05072885DD1D00CE9DE7 /* DomainCallbacks.h in Headers */,
 				538E050B2885E53700CE9DE7 /* DomainCommon.h in Headers */,
 				538E05032885DCED00CE9DE7 /* DomainObject.h in Headers */,
+				532CA240291ED1F9008FA673 /* MediaPlayerSliderCell.h in Headers */,
 				5309C4212885CB1400BC0AAE /* DataTransferObject.h in Headers */,
 				5309C40F2885B43B00BC0AAE /* ObjectCache.h in Headers */,
 				538E05132885ED2200CE9DE7 /* ObjectRepository.h in Headers */,
@@ -1372,6 +1379,7 @@
 				5309C3AE2885A1DC00BC0AAE /* CoreZen.docc in Sources */,
 				538E05142885ED2200CE9DE7 /* ObjectRepository.m in Sources */,
 				5350FB0728889E7400F8CA68 /* Node.m in Sources */,
+				532CA241291ED1F9008FA673 /* MediaPlayerSliderCell.m in Sources */,
 				5309C3F22885A74A00BC0AAE /* ObjectIdentifier.m in Sources */,
 				5396532E288F453E007B53EC /* MPVRenderController.m in Sources */,
 				5350F8C32886194200F8CA68 /* MediaFile.m in Sources */,

--- a/CoreZen/Media/Interfaces/MediaPlayer+Private.h
+++ b/CoreZen/Media/Interfaces/MediaPlayer+Private.h
@@ -16,6 +16,7 @@
 
 @property (nonatomic) BOOL paused;
 @property (nonatomic) double positionPercent;
+@property (nonatomic) BOOL seeking;
 
 // Reciprocal of ZENMediaPlayerView attachPlayer:
 - (void)attachPlayerView:(ZENMediaPlayerView *)view;

--- a/CoreZen/Media/MPV/MPVPlayerController.m
+++ b/CoreZen/Media/MPV/MPVPlayerController.m
@@ -269,10 +269,16 @@ static void zen_mpv_wakeup(void *ctx);
 			}
 			case MPV_EVENT_SEEK: {
 				NSLog(@"MPV_EVENT_SEEK");
+				dispatch_async(dispatch_get_main_queue(), ^{
+					self.player.seeking = YES;
+				});
 				break;
 			}
 			case MPV_EVENT_PLAYBACK_RESTART: {
 				NSLog(@"MPV_EVENT_PLAYBACK_RESTART");
+				dispatch_async(dispatch_get_main_queue(), ^{
+					self.player.seeking = NO;
+				});
 				break;
 			}
 			case MPV_EVENT_PROPERTY_CHANGE: {

--- a/CoreZen/Media/MediaPlayer.h
+++ b/CoreZen/Media/MediaPlayer.h
@@ -20,6 +20,7 @@
 // Observe these properties for updates to the UI. They will only change on the main thread.
 @property (nonatomic, readonly) BOOL paused;
 @property (nonatomic, readonly) double positionPercent;
+@property (nonatomic, readonly) BOOL seeking;
 
 // Terminate and detach the player view, terminate player controller
 - (void)terminatePlayer;

--- a/CoreZen/Media/MediaPlayer.m
+++ b/CoreZen/Media/MediaPlayer.m
@@ -84,15 +84,24 @@ ZENObjectCache* ZENGetWeakMediaPlayerCache(void) {
 }
 
 - (void)seekRelativeSeconds:(double)seconds {
-	[self.playerController seekBySeconds:seconds];
+	if (!self.seeking) {
+		self.seeking = YES;
+		[self.playerController seekBySeconds:seconds];
+	}
 }
 
 - (void)seekAbsoluteSeconds:(double)seconds {
-	[self.playerController seekToSeconds:seconds];
+	if (!self.seeking) {
+		self.seeking = YES;
+		[self.playerController seekToSeconds:seconds];
+	}
 }
 
 - (void)seekAbsolutePercentage:(double)percentage {
-	[self.playerController seekToPercentage:percentage];
+	if (!self.seeking) {
+		self.seeking = YES;
+		[self.playerController seekToPercentage:percentage];
+	}
 }
 
 @end

--- a/CoreZen/Media/Views/MediaPlayerCTIView.m
+++ b/CoreZen/Media/Views/MediaPlayerCTIView.m
@@ -13,7 +13,6 @@ static void* ObserverContext = &ObserverContext;
 @interface ZENMediaPlayerCTIView ()
 
 @property (nonatomic, weak) IBOutlet NSSlider *slider;
-@property (nonatomic, weak) IBOutlet ZENMediaPlayerPeekView *peekView;
 
 - (IBAction)sliderChanged:(id)sender;
 

--- a/CoreZen/Media/Views/MediaPlayerCTIView.m
+++ b/CoreZen/Media/Views/MediaPlayerCTIView.m
@@ -12,7 +12,10 @@ static void* ObserverContext = &ObserverContext;
 
 @interface ZENMediaPlayerCTIView ()
 
-@property (nonatomic, weak) IBOutlet NSProgressIndicator *progressBar;
+@property (nonatomic, weak) IBOutlet NSSlider *slider;
+@property (nonatomic, weak) IBOutlet ZENMediaPlayerPeekView *peekView;
+
+- (IBAction)sliderChanged:(id)sender;
 
 @property (nonatomic, weak) ZENMediaPlayer *player;
 @property (nonatomic) BOOL scrubbing;
@@ -28,9 +31,10 @@ static void* ObserverContext = &ObserverContext;
 - (void)initCommon {
 	[super initCommon];
 	
-	self.progressBar.minValue = 0.0;
-	self.progressBar.maxValue = 100.0;
 	self.scrubbing = NO;
+	
+	self.slider.minValue = 0.0;
+	self.slider.maxValue = 100.0;
 }
 
 - (void)attachPlayer:(ZENMediaPlayer *)player {

--- a/CoreZen/Media/Views/MediaPlayerCTIView.m
+++ b/CoreZen/Media/Views/MediaPlayerCTIView.m
@@ -15,6 +15,7 @@ static void* ObserverContext = &ObserverContext;
 @property (nonatomic, weak) IBOutlet NSProgressIndicator *progressBar;
 
 @property (nonatomic, weak) ZENMediaPlayer *player;
+@property (nonatomic) BOOL scrubbing;
 
 @end
 
@@ -29,6 +30,7 @@ static void* ObserverContext = &ObserverContext;
 	
 	self.progressBar.minValue = 0.0;
 	self.progressBar.maxValue = 100.0;
+	self.scrubbing = NO;
 }
 
 - (void)attachPlayer:(ZENMediaPlayer *)player {
@@ -49,10 +51,27 @@ static void* ObserverContext = &ObserverContext;
 	if (context == ObserverContext) {
 		if (object == self.player) {
 			if ([keyPath isEqualToString:@"positionPercent"]) {
-				NSNumber *positionPercent = [change objectForKey:NSKeyValueChangeNewKey];
-				self.progressBar.doubleValue = positionPercent.doubleValue;
+				if (!self.scrubbing) {
+					NSNumber *positionPercent = [change objectForKey:NSKeyValueChangeNewKey];
+					self.slider.doubleValue = positionPercent.doubleValue;
+				}
 			}
 		}
+	}
+}
+
+- (IBAction)sliderChanged:(id)sender {
+	NSEvent *event = NSApplication.sharedApplication.currentEvent;
+	NSEventType eventType = event.type;
+	
+	if (eventType == NSEventTypeLeftMouseDown || eventType == NSEventTypeLeftMouseDragged) {
+		self.scrubbing = YES;
+		
+		double percentage = self.slider.doubleValue;
+		[self.player seekAbsolutePercentage:percentage];
+		
+	} else if (eventType == NSEventTypeLeftMouseUp) {
+		self.scrubbing = NO;
 	}
 }
 

--- a/CoreZen/Media/Views/MediaPlayerSliderCell.h
+++ b/CoreZen/Media/Views/MediaPlayerSliderCell.h
@@ -1,0 +1,12 @@
+//
+//  MediaPlayerSliderCell.h
+//  CoreZen
+//
+//  Created by Zach Nelson on 11/11/22.
+//
+
+#import <Cocoa/Cocoa.h>
+
+@interface ZENMediaPlayerSliderCell : NSSliderCell
+
+@end

--- a/CoreZen/Media/Views/MediaPlayerSliderCell.m
+++ b/CoreZen/Media/Views/MediaPlayerSliderCell.m
@@ -1,0 +1,15 @@
+//
+//  MediaPlayerSliderCell.m
+//  CoreZen
+//
+//  Created by Zach Nelson on 11/11/22.
+//
+
+#import "MediaPlayerSliderCell.h"
+
+@implementation ZENMediaPlayerSliderCell
+
+// TODO: draw custom slider:
+// - (void)drawKnob:(NSRect)knobRect;
+
+@end

--- a/CoreZen/Media/Views/Nibs/ZENMediaPlayerCTIView.xib
+++ b/CoreZen/Media/Views/Nibs/ZENMediaPlayerCTIView.xib
@@ -1,31 +1,36 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="21225" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" customObjectInstantitationMethod="direct">
+<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="21507" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" customObjectInstantitationMethod="direct">
     <dependencies>
         <deployment identifier="macosx"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="21225"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="21507"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
         <customObject id="-2" userLabel="File's Owner" customClass="ZENMediaPlayerCTIView">
             <connections>
-                <outlet property="progressBar" destination="QQ2-mR-tl1" id="qb1-78-i94"/>
+                <outlet property="peekView" destination="CbS-EO-qut" id="rVG-4b-NNf"/>
                 <outlet property="rootView" destination="c22-O7-iKe" id="ElT-Au-SCX"/>
+                <outlet property="slider" destination="Kcy-pW-27Q" id="Ger-lQ-7ny"/>
             </connections>
         </customObject>
         <customObject id="-1" userLabel="First Responder" customClass="FirstResponder"/>
         <customObject id="-3" userLabel="Application" customClass="NSObject"/>
-        <customView translatesAutoresizingMaskIntoConstraints="NO" id="c22-O7-iKe" userLabel="CTI View">
-            <rect key="frame" x="0.0" y="0.0" width="480" height="272"/>
+        <customView misplaced="YES" translatesAutoresizingMaskIntoConstraints="NO" id="c22-O7-iKe" userLabel="CTI View">
+            <rect key="frame" x="0.0" y="0.0" width="480" height="16"/>
             <subviews>
-                <progressIndicator maxValue="100" doubleValue="50" style="bar" translatesAutoresizingMaskIntoConstraints="NO" id="QQ2-mR-tl1">
-                    <rect key="frame" x="0.0" y="-1" width="480" height="274"/>
-                </progressIndicator>
+                <slider verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="Kcy-pW-27Q">
+                    <rect key="frame" x="-1" y="-5" width="482" height="28"/>
+                    <sliderCell key="cell" continuous="YES" state="on" alignment="left" maxValue="100" doubleValue="50" tickMarkPosition="above" sliderType="linear" id="Jmp-Oi-f1D" customClass="ZENMediaPlayerSliderCell"/>
+                    <connections>
+                        <action selector="sliderChanged:" target="-2" id="adb-uW-Csu"/>
+                    </connections>
+                </slider>
             </subviews>
             <constraints>
-                <constraint firstAttribute="bottom" secondItem="QQ2-mR-tl1" secondAttribute="bottom" id="5Yk-Hi-KmL"/>
-                <constraint firstItem="QQ2-mR-tl1" firstAttribute="leading" secondItem="c22-O7-iKe" secondAttribute="leading" id="IRS-Ke-PK3"/>
-                <constraint firstItem="QQ2-mR-tl1" firstAttribute="top" secondItem="c22-O7-iKe" secondAttribute="top" id="L3u-lY-bh0"/>
-                <constraint firstAttribute="trailing" secondItem="QQ2-mR-tl1" secondAttribute="trailing" id="Nb6-Mh-b3W"/>
+                <constraint firstItem="Kcy-pW-27Q" firstAttribute="top" secondItem="c22-O7-iKe" secondAttribute="top" constant="1" id="VIy-bO-UKR"/>
+                <constraint firstItem="Kcy-pW-27Q" firstAttribute="leading" secondItem="c22-O7-iKe" secondAttribute="leading" constant="1" id="fab-OZ-cAS"/>
+                <constraint firstAttribute="bottom" secondItem="Kcy-pW-27Q" secondAttribute="bottom" constant="1" id="o5t-Se-YJf"/>
+                <constraint firstAttribute="trailing" secondItem="Kcy-pW-27Q" secondAttribute="trailing" constant="1" id="x0J-UD-NCD"/>
             </constraints>
             <point key="canvasLocation" x="79" y="154"/>
         </customView>

--- a/CoreZen/Media/Views/Nibs/ZENMediaPlayerControlsView.xib
+++ b/CoreZen/Media/Views/Nibs/ZENMediaPlayerControlsView.xib
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="21225" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" customObjectInstantitationMethod="direct">
+<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="21507" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" customObjectInstantitationMethod="direct">
     <dependencies>
         <deployment identifier="macosx"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="21225"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="21507"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>


### PR DESCRIPTION
Added support for scrubbing / seeking by clicking the playback slider. (This change replaces the progress bar with an NSSlider to better support user interaction.) The slider handles continuous changes and stops updating in response to mpv position updates during click-and-drag scrubbing. This also adds a seeking property to media player, currently used to avoid sending a second seek command to mpv while waiting for the first one to be handled. 