### PR TITLE
Peek frames on hover

### DIFF
--- a/CoreZen.xcodeproj/project.pbxproj
+++ b/CoreZen.xcodeproj/project.pbxproj
@@ -56,6 +56,7 @@
 		533005DE28F784B600E59E1D /* ZENMediaPlayerControlsView.xib in Resources */ = {isa = PBXBuildFile; fileRef = 533005DD28F784B600E59E1D /* ZENMediaPlayerControlsView.xib */; };
 		5331FE612922AD8700C15950 /* WorkQueue.h in Headers */ = {isa = PBXBuildFile; fileRef = 5331FE5F2922AD8700C15950 /* WorkQueue.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		5331FE622922AD8700C15950 /* WorkQueue.m in Sources */ = {isa = PBXBuildFile; fileRef = 5331FE602922AD8700C15950 /* WorkQueue.m */; };
+		5331FE682922DF6400C15950 /* WorkQueueTypes.h in Headers */ = {isa = PBXBuildFile; fileRef = 5331FE672922DF3600C15950 /* WorkQueueTypes.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		5350F8A42886020500F8CA68 /* DatabaseTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 5350F8A32886020500F8CA68 /* DatabaseTests.m */; };
 		5350F8B42886074F00F8CA68 /* ObjectCacheTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 5350F8B32886074F00F8CA68 /* ObjectCacheTests.m */; };
 		5350F8B72886080500F8CA68 /* CategoryTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 5350F8B62886080500F8CA68 /* CategoryTests.m */; };
@@ -359,6 +360,7 @@
 		533005DD28F784B600E59E1D /* ZENMediaPlayerControlsView.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = ZENMediaPlayerControlsView.xib; sourceTree = "<group>"; };
 		5331FE5F2922AD8700C15950 /* WorkQueue.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = WorkQueue.h; sourceTree = "<group>"; };
 		5331FE602922AD8700C15950 /* WorkQueue.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = WorkQueue.m; sourceTree = "<group>"; };
+		5331FE672922DF3600C15950 /* WorkQueueTypes.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = WorkQueueTypes.h; sourceTree = "<group>"; };
 		5350F8A32886020500F8CA68 /* DatabaseTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = DatabaseTests.m; sourceTree = "<group>"; };
 		5350F8B32886074F00F8CA68 /* ObjectCacheTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = ObjectCacheTests.m; sourceTree = "<group>"; };
 		5350F8B62886080500F8CA68 /* CategoryTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = CategoryTests.m; sourceTree = "<group>"; };
@@ -819,6 +821,7 @@
 			children = (
 				5331FE5F2922AD8700C15950 /* WorkQueue.h */,
 				5331FE602922AD8700C15950 /* WorkQueue.m */,
+				5331FE672922DF3600C15950 /* WorkQueueTypes.h */,
 			);
 			path = Queue;
 			sourceTree = "<group>";
@@ -1266,6 +1269,7 @@
 				5356FE7428A459BA00ECCA92 /* MediaPlayer+Private.h in Headers */,
 				5356FE7028A4595800ECCA92 /* MediaPlayerView+Private.h in Headers */,
 				531673662909C1DD003FB35A /* MediaPlayerCTIView.h in Headers */,
+				5331FE682922DF6400C15950 /* WorkQueueTypes.h in Headers */,
 				532CA223291B090E008FA673 /* FrameRenderer.h in Headers */,
 				5331FE612922AD8700C15950 /* WorkQueue.h in Headers */,
 				532CA23D291D8152008FA673 /* FrameRendererTypes.h in Headers */,

--- a/CoreZen.xcodeproj/project.pbxproj
+++ b/CoreZen.xcodeproj/project.pbxproj
@@ -48,6 +48,8 @@
 		532CA235291B1E96008FA673 /* LibAVRenderController.m in Sources */ = {isa = PBXBuildFile; fileRef = 532CA233291B1E96008FA673 /* LibAVRenderController.m */; };
 		532CA236291B1F73008FA673 /* FrameRenderController.h in Headers */ = {isa = PBXBuildFile; fileRef = 532CA22F291B1B85008FA673 /* FrameRenderController.h */; };
 		532CA237291C5C65008FA673 /* libswscale.6.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = 539A15B128DA2099007D001A /* libswscale.6.dylib */; };
+		532CA23A291D8050008FA673 /* MediaPlayerPeekView.h in Headers */ = {isa = PBXBuildFile; fileRef = 532CA238291D8050008FA673 /* MediaPlayerPeekView.h */; };
+		532CA23B291D8050008FA673 /* MediaPlayerPeekView.m in Sources */ = {isa = PBXBuildFile; fileRef = 532CA239291D8050008FA673 /* MediaPlayerPeekView.m */; };
 		532CA23D291D8152008FA673 /* FrameRendererTypes.h in Headers */ = {isa = PBXBuildFile; fileRef = 532CA23C291D8152008FA673 /* FrameRendererTypes.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		532CA240291ED1F9008FA673 /* MediaPlayerSliderCell.h in Headers */ = {isa = PBXBuildFile; fileRef = 532CA23E291ED1F9008FA673 /* MediaPlayerSliderCell.h */; };
 		532CA241291ED1F9008FA673 /* MediaPlayerSliderCell.m in Sources */ = {isa = PBXBuildFile; fileRef = 532CA23F291ED1F9008FA673 /* MediaPlayerSliderCell.m */; };
@@ -349,6 +351,8 @@
 		532CA230291B1C8B008FA673 /* FrameRenderer+Private.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "FrameRenderer+Private.h"; sourceTree = "<group>"; };
 		532CA232291B1E96008FA673 /* LibAVRenderController.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = LibAVRenderController.h; sourceTree = "<group>"; };
 		532CA233291B1E96008FA673 /* LibAVRenderController.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = LibAVRenderController.m; sourceTree = "<group>"; };
+		532CA238291D8050008FA673 /* MediaPlayerPeekView.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MediaPlayerPeekView.h; sourceTree = "<group>"; };
+		532CA239291D8050008FA673 /* MediaPlayerPeekView.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MediaPlayerPeekView.m; sourceTree = "<group>"; };
 		532CA23C291D8152008FA673 /* FrameRendererTypes.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = FrameRendererTypes.h; path = CoreZen/Media/FrameRendererTypes.h; sourceTree = SOURCE_ROOT; };
 		532CA23E291ED1F9008FA673 /* MediaPlayerSliderCell.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MediaPlayerSliderCell.h; sourceTree = "<group>"; };
 		532CA23F291ED1F9008FA673 /* MediaPlayerSliderCell.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MediaPlayerSliderCell.m; sourceTree = "<group>"; };
@@ -782,6 +786,8 @@
 				5386706928BFE16300FB15EB /* MediaPlayerControlsView.m */,
 				531673642909C1DD003FB35A /* MediaPlayerCTIView.h */,
 				531673652909C1DD003FB35A /* MediaPlayerCTIView.m */,
+				532CA238291D8050008FA673 /* MediaPlayerPeekView.h */,
+				532CA239291D8050008FA673 /* MediaPlayerPeekView.m */,
 				532CA23E291ED1F9008FA673 /* MediaPlayerSliderCell.h */,
 				532CA23F291ED1F9008FA673 /* MediaPlayerSliderCell.m */,
 			);
@@ -1248,6 +1254,7 @@
 				5309C3E82885A39C00BC0AAE /* PreferencesWindowController.h in Headers */,
 				538E05072885DD1D00CE9DE7 /* DomainCallbacks.h in Headers */,
 				538E050B2885E53700CE9DE7 /* DomainCommon.h in Headers */,
+				532CA23A291D8050008FA673 /* MediaPlayerPeekView.h in Headers */,
 				538E05032885DCED00CE9DE7 /* DomainObject.h in Headers */,
 				532CA240291ED1F9008FA673 /* MediaPlayerSliderCell.h in Headers */,
 				5309C4212885CB1400BC0AAE /* DataTransferObject.h in Headers */,
@@ -1410,6 +1417,7 @@
 				5309C40B2885B15400BC0AAE /* NSNumber+CoreZen.m in Sources */,
 				532CA235291B1E96008FA673 /* LibAVRenderController.m in Sources */,
 				5356FE5928A4290000ECCA92 /* MPVConstants.m in Sources */,
+				532CA23B291D8050008FA673 /* MediaPlayerPeekView.m in Sources */,
 				538E050C2885E53700CE9DE7 /* DomainCommon.m in Sources */,
 				5309C4022885B11400BC0AAE /* NSFileManager+CoreZen.m in Sources */,
 			);

--- a/CoreZen.xcodeproj/project.pbxproj
+++ b/CoreZen.xcodeproj/project.pbxproj
@@ -57,6 +57,7 @@
 		5331FE612922AD8700C15950 /* WorkQueue.h in Headers */ = {isa = PBXBuildFile; fileRef = 5331FE5F2922AD8700C15950 /* WorkQueue.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		5331FE622922AD8700C15950 /* WorkQueue.m in Sources */ = {isa = PBXBuildFile; fileRef = 5331FE602922AD8700C15950 /* WorkQueue.m */; };
 		5331FE682922DF6400C15950 /* WorkQueueTypes.h in Headers */ = {isa = PBXBuildFile; fileRef = 5331FE672922DF3600C15950 /* WorkQueueTypes.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		5331FE6A2922E9DC00C15950 /* WorkQueue+Private.h in Headers */ = {isa = PBXBuildFile; fileRef = 5331FE692922E9DC00C15950 /* WorkQueue+Private.h */; };
 		5350F8A42886020500F8CA68 /* DatabaseTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 5350F8A32886020500F8CA68 /* DatabaseTests.m */; };
 		5350F8B42886074F00F8CA68 /* ObjectCacheTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 5350F8B32886074F00F8CA68 /* ObjectCacheTests.m */; };
 		5350F8B72886080500F8CA68 /* CategoryTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 5350F8B62886080500F8CA68 /* CategoryTests.m */; };
@@ -361,6 +362,7 @@
 		5331FE5F2922AD8700C15950 /* WorkQueue.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = WorkQueue.h; sourceTree = "<group>"; };
 		5331FE602922AD8700C15950 /* WorkQueue.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = WorkQueue.m; sourceTree = "<group>"; };
 		5331FE672922DF3600C15950 /* WorkQueueTypes.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = WorkQueueTypes.h; sourceTree = "<group>"; };
+		5331FE692922E9DC00C15950 /* WorkQueue+Private.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "WorkQueue+Private.h"; sourceTree = "<group>"; };
 		5350F8A32886020500F8CA68 /* DatabaseTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = DatabaseTests.m; sourceTree = "<group>"; };
 		5350F8B32886074F00F8CA68 /* ObjectCacheTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = ObjectCacheTests.m; sourceTree = "<group>"; };
 		5350F8B62886080500F8CA68 /* CategoryTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = CategoryTests.m; sourceTree = "<group>"; };
@@ -821,6 +823,7 @@
 			children = (
 				5331FE5F2922AD8700C15950 /* WorkQueue.h */,
 				5331FE602922AD8700C15950 /* WorkQueue.m */,
+				5331FE692922E9DC00C15950 /* WorkQueue+Private.h */,
 				5331FE672922DF3600C15950 /* WorkQueueTypes.h */,
 			);
 			path = Queue;
@@ -1261,6 +1264,7 @@
 				538E05032885DCED00CE9DE7 /* DomainObject.h in Headers */,
 				532CA240291ED1F9008FA673 /* MediaPlayerSliderCell.h in Headers */,
 				5309C4212885CB1400BC0AAE /* DataTransferObject.h in Headers */,
+				5331FE6A2922E9DC00C15950 /* WorkQueue+Private.h in Headers */,
 				5309C40F2885B43B00BC0AAE /* ObjectCache.h in Headers */,
 				538E05132885ED2200CE9DE7 /* ObjectRepository.h in Headers */,
 				5350FB0628889E7400F8CA68 /* Node.h in Headers */,

--- a/CoreZen/Media/FrameRenderer.h
+++ b/CoreZen/Media/FrameRenderer.h
@@ -48,4 +48,9 @@
 									 height:(NSUInteger)height
 								 completion:(ZENRenderFrameResultsBlock)completion;
 
+- (ZENCancelToken *)renderFrames:(NSUInteger)count
+						   width:(NSUInteger)width
+						  height:(NSUInteger)height
+					  completion:(ZENRenderFramesResultsBlock)completion;
+
 @end

--- a/CoreZen/Media/FrameRenderer.h
+++ b/CoreZen/Media/FrameRenderer.h
@@ -7,6 +7,7 @@
 
 #import <Foundation/Foundation.h>
 #import <CoreZen/FrameRendererTypes.h>
+#import <CoreZen/WorkQueueTypes.h>
 
 // Rendered frame result
 @interface ZENRenderedFrame : NSObject
@@ -37,14 +38,14 @@
 - (instancetype)initWithController:(NSObject<ZENFrameRenderController> *)controller
 						 mediaFile:(ZENMediaFile *)mediaFile;
 
-- (void)renderFrameAtSeconds:(double)seconds
-					   width:(NSUInteger)width
-					  height:(NSUInteger)height
-				  completion:(ZENFrameRendererResultsBlock)completion;
+- (ZENCancelToken *)renderFrameAtSeconds:(double)seconds
+								   width:(NSUInteger)width
+								  height:(NSUInteger)height
+							  completion:(ZENRenderFrameResultsBlock)completion;
 
-- (void)renderFrameAtPercentage:(double)percentage
-						  width:(NSUInteger)width
-						 height:(NSUInteger)height
-					 completion:(ZENFrameRendererResultsBlock)completion;
+- (ZENCancelToken *)renderFrameAtPercentage:(double)percentage
+									  width:(NSUInteger)width
+									 height:(NSUInteger)height
+								 completion:(ZENRenderFrameResultsBlock)completion;
 
 @end

--- a/CoreZen/Media/FrameRenderer.m
+++ b/CoreZen/Media/FrameRenderer.m
@@ -7,8 +7,56 @@
 
 #import "FrameRenderer+Private.h"
 #import "FrameRenderController.h"
+#import "WorkQueue+Private.h"
 
 @implementation ZENRenderedFrame
+@end
+
+@interface ZENRenderedFrameCollector : NSObject
+
+@property (nonatomic, readonly) NSUInteger count;
+@property (nonatomic, strong, readonly) ZENRenderFramesResultsBlock completion;
+@property (nonatomic, strong, readonly) NSMutableArray<ZENRenderedFrame *> *frames;
+@property (nonatomic, strong, readonly) NSLock *lock;
+
+- (instancetype)initWithCount:(NSUInteger)count
+				   completion:(ZENRenderFramesResultsBlock)completion;
+
+- (void)collect:(ZENRenderedFrame *)frame;
+
+@end
+
+@implementation ZENRenderedFrameCollector
+
+- (instancetype)initWithCount:(NSUInteger)count
+				   completion:(ZENRenderFramesResultsBlock)completion {
+	self = [super init];
+	if (self) {
+		_count = count;
+		_completion = completion;
+		_frames = [NSMutableArray new];
+		_lock = [NSLock new];
+	}
+	return self;
+}
+
+- (void)collect:(ZENRenderedFrame *)frame {
+	NSArray<ZENRenderedFrame *> *result = nil;
+	
+	[self.lock lock];
+	
+	[self.frames addObject:frame];
+	if (self.frames.count == self.count) {
+		result = self.frames;
+	}
+
+	[self.lock unlock];
+	
+	if (result) {
+		self.completion(result);
+	}
+}
+
 @end
 
 @implementation ZENFrameRenderer
@@ -43,6 +91,45 @@
 	frame.requestedPercentage = percentage;
 	
 	return [self.frameRenderController renderFrame:frame size:NSMakeSize(width, height) completion:completion];
+}
+
+- (ZENCancelToken *)renderFrames:(NSUInteger)count
+						   width:(NSUInteger)width
+						  height:(NSUInteger)height
+					  completion:(ZENRenderFramesResultsBlock)completion {
+	ZENCancelToken *result = nil;
+	if (count > 2) {
+		NSUInteger denominator = (count - 1);
+		ZENRenderedFrameCollector *collector = [[ZENRenderedFrameCollector alloc] initWithCount:count completion:completion];
+		NSMutableArray<ZENWorkQueueToken *> *tokens = [NSMutableArray new];
+		
+		for (NSUInteger index = 0; index < count; ++index) {
+			double percentage = index / denominator;
+			
+			// Scale to 1% to 99% range
+			const double kBufferPercentage = 0.01;
+			const double kScaledPercentage = 1.00 - (2 * kBufferPercentage);
+			percentage = (percentage * kScaledPercentage) + kBufferPercentage;
+			
+			ZENCancelToken *token = [self renderFrameAtPercentage:percentage
+															width:width
+														   height:height
+													   completion:^(ZENRenderedFrame *frame) {
+				[collector collect:frame];
+			}];
+			
+			[tokens addObject:token];
+		}
+		
+		result = [[ZENWorkQueueMultiToken alloc] initWithTokens:tokens];
+		
+	} else if (count == 1) {
+		result = [self renderFrameAtPercentage:0.50 width:width height:height completion:^(ZENRenderedFrame *frame) {
+			NSArray *frames = @[frame];
+			completion(frames);
+		}];
+	}
+	return result;
 }
 
 @end

--- a/CoreZen/Media/FrameRenderer.m
+++ b/CoreZen/Media/FrameRenderer.m
@@ -98,18 +98,13 @@
 						  height:(NSUInteger)height
 					  completion:(ZENRenderFramesResultsBlock)completion {
 	ZENCancelToken *result = nil;
-	if (count > 2) {
-		NSUInteger denominator = (count - 1);
+	if (count >= 2) {
 		ZENRenderedFrameCollector *collector = [[ZENRenderedFrameCollector alloc] initWithCount:count completion:completion];
 		NSMutableArray<ZENWorkQueueToken *> *tokens = [NSMutableArray new];
+		double denominator = count - 1;
 		
 		for (NSUInteger index = 0; index < count; ++index) {
 			double percentage = index / denominator;
-			
-			// Scale to 1% to 99% range
-			const double kBufferPercentage = 0.01;
-			const double kScaledPercentage = 1.00 - (2 * kBufferPercentage);
-			percentage = (percentage * kScaledPercentage) + kBufferPercentage;
 			
 			ZENCancelToken *token = [self renderFrameAtPercentage:percentage
 															width:width

--- a/CoreZen/Media/FrameRenderer.m
+++ b/CoreZen/Media/FrameRenderer.m
@@ -23,26 +23,26 @@
 	return self;
 }
 
-- (void)renderFrameAtSeconds:(double)seconds
-					   width:(NSUInteger)width
-					  height:(NSUInteger)height
-				  completion:(ZENFrameRendererResultsBlock)completion {
+- (ZENCancelToken *)renderFrameAtSeconds:(double)seconds
+								   width:(NSUInteger)width
+								  height:(NSUInteger)height
+							  completion:(ZENRenderFrameResultsBlock)completion {
 	
 	ZENRenderedFrame *frame = [ZENRenderedFrame new];
 	frame.requestedSeconds = seconds;
 	
-	[self.frameRenderController renderFrame:frame size:NSMakeSize(width, height) completion:completion];
+	return [self.frameRenderController renderFrame:frame size:NSMakeSize(width, height) completion:completion];
 }
 
-- (void)renderFrameAtPercentage:(double)percentage
-						  width:(NSUInteger)width
-						 height:(NSUInteger)height
-					 completion:(ZENFrameRendererResultsBlock)completion {
+- (ZENCancelToken *)renderFrameAtPercentage:(double)percentage
+									  width:(NSUInteger)width
+									 height:(NSUInteger)height
+								 completion:(ZENRenderFrameResultsBlock)completion {
 	
 	ZENRenderedFrame *frame = [ZENRenderedFrame new];
 	frame.requestedPercentage = percentage;
 	
-	[self.frameRenderController renderFrame:frame size:NSMakeSize(width, height) completion:completion];
+	return [self.frameRenderController renderFrame:frame size:NSMakeSize(width, height) completion:completion];
 }
 
 @end

--- a/CoreZen/Media/FrameRendererTypes.h
+++ b/CoreZen/Media/FrameRendererTypes.h
@@ -10,4 +10,4 @@
 @class ZENRenderedFrame;
 
 // Completion block type
-typedef void (^ZENFrameRendererResultsBlock)(ZENRenderedFrame *frame);
+typedef void (^ZENRenderFrameResultsBlock)(ZENRenderedFrame *frame);

--- a/CoreZen/Media/FrameRendererTypes.h
+++ b/CoreZen/Media/FrameRendererTypes.h
@@ -9,5 +9,6 @@
 
 @class ZENRenderedFrame;
 
-// Completion block type
+// Completion block types
 typedef void (^ZENRenderFrameResultsBlock)(ZENRenderedFrame *frame);
+typedef void (^ZENRenderFramesResultsBlock)(NSArray<ZENRenderedFrame *> *frames);

--- a/CoreZen/Media/Interfaces/FrameRenderController.h
+++ b/CoreZen/Media/Interfaces/FrameRenderController.h
@@ -7,13 +7,14 @@
 
 #import <Foundation/Foundation.h>
 #import <CoreZen/FrameRendererTypes.h>
+#import <CoreZen/WorkQueueTypes.h>
 
 @protocol ZENFrameRenderController <NSObject>
 
 - (void)terminate;
 
-- (void)renderFrame:(ZENRenderedFrame *)renderedFrame
-			   size:(NSSize)size
-		 completion:(ZENFrameRendererResultsBlock)completion;
+- (ZENCancelToken *)renderFrame:(ZENRenderedFrame *)renderedFrame
+						   size:(NSSize)size
+					 completion:(ZENRenderFrameResultsBlock)completion;
 
 @end

--- a/CoreZen/Media/Interfaces/MediaPlayer+Private.h
+++ b/CoreZen/Media/Interfaces/MediaPlayer+Private.h
@@ -14,6 +14,7 @@
 @property (nonatomic, strong) ZENMediaPlayerView *playerView;
 @property (nonatomic, strong, readonly) NSObject<ZENMediaPlayerController> *playerController;
 
+@property (nonatomic, strong) NSURL *fileURL;
 @property (nonatomic) BOOL paused;
 @property (nonatomic) double positionPercent;
 @property (nonatomic) BOOL seeking;

--- a/CoreZen/Media/Interfaces/MediaPlayerController.h
+++ b/CoreZen/Media/Interfaces/MediaPlayerController.h
@@ -15,6 +15,8 @@
 // (mpv_handle *)playerHandle;
 - (void *)playerHandle;
 
+- (void)openFileURL:(NSURL *)url;
+
 - (void)startPlayback;
 - (void)pausePlayback;
 

--- a/CoreZen/Media/LibAV/LibAVRenderController.h
+++ b/CoreZen/Media/LibAV/LibAVRenderController.h
@@ -19,8 +19,8 @@
 
 - (void)terminate;
 
-- (void)renderFrame:(ZENRenderedFrame *)renderedFrame
-			   size:(NSSize)size
-		 completion:(ZENFrameRendererResultsBlock)completion;
+- (ZENCancelToken *)renderFrame:(ZENRenderedFrame *)renderedFrame
+						   size:(NSSize)size
+					 completion:(ZENRenderFrameResultsBlock)completion;
 
 @end

--- a/CoreZen/Media/LibAV/LibAVRenderController.m
+++ b/CoreZen/Media/LibAV/LibAVRenderController.m
@@ -229,11 +229,11 @@
 	return image;
 }
 
-- (void)renderFrame:(ZENRenderedFrame *)renderedFrame
-			   size:(NSSize)size
-		 completion:(ZENFrameRendererResultsBlock)completion {
+- (ZENCancelToken *)renderFrame:(ZENRenderedFrame *)renderedFrame
+						   size:(NSSize)size
+					 completion:(ZENRenderFrameResultsBlock)completion {
 	
-	[self.workQueue async:^(ZENCancelToken *canceled) {
+	return [self.workQueue async:^(ZENCancelToken *canceled) {
 		if (!canceled.canceled) {
 			NSObject<ZENMediaInfoController> *infoController = self.infoController;
 			

--- a/CoreZen/Media/LibAV/LibAVRenderController.m
+++ b/CoreZen/Media/LibAV/LibAVRenderController.m
@@ -122,15 +122,15 @@
 				}
 				
 				result = avcodec_receive_frame(_codecContext, frame);
-				if (result < 0) {
-					if (result == AVERROR(EAGAIN)) {
-						NSLog(@"avcodec_receive_frame failed: EAGAIN (input not ready, retrying)");
-						continue;
-					} else {
-						NSLog(@"avcodec_receive_frame failed: %d", result);
-						break;
-					}
+				if (result == AVERROR(EAGAIN)) {
+					NSLog(@"avcodec_receive_frame failed: EAGAIN (input not ready, retrying)");
+					continue;
 				}
+				
+				if (result < 0) {
+					NSLog(@"avcodec_receive_frame failed: %d", result);
+				}
+				break;
 			}
 		} @catch (NSException *exception) {
 			NSLog(@"Exception caught during decode: %@", exception);

--- a/CoreZen/Media/LibAV/LibAVRenderController.m
+++ b/CoreZen/Media/LibAV/LibAVRenderController.m
@@ -251,11 +251,11 @@
 			AVFormatContext *formatContext = infoController.formatContextHandle;
 			const AVStream *stream = infoController.videoStreamHandle;
 			
-			int64_t durationTicks = formatContext->duration;
+			int64_t durationAVTicks = formatContext->duration;
 			
 			// Get duration in terms of the video stream time base (instead of overall libav time base)
-			int64_t duration = av_rescale_q(durationTicks, AV_TIME_BASE_Q, stream->time_base);
-			int64_t frameTimestamp = duration * renderedFrame.requestedPercentage;
+			int64_t durationStreamTicks = av_rescale_q(durationAVTicks, AV_TIME_BASE_Q, stream->time_base);
+			int64_t frameTimestamp = durationStreamTicks * renderedFrame.requestedPercentage;
 			
 			renderedFrame.requestedTimestamp = frameTimestamp;
 			
@@ -265,7 +265,7 @@
 			if ([self renderRawFrame:rawFrame formatContext:formatContext stream:stream timestamp:frameTimestamp]) {
 				
 				renderedFrame.actualTimestamp = rawFrame->best_effort_timestamp;
-				renderedFrame.actualPercentage = renderedFrame.actualTimestamp / (double)durationTicks;
+				renderedFrame.actualPercentage = renderedFrame.actualTimestamp / (double)durationStreamTicks;
 				renderedFrame.actualSeconds = renderedFrame.actualPercentage * durationSeconds;
 				
 				// Resize the frame to desired size, convert to RGB

--- a/CoreZen/Media/MPV/MPVConstants.h
+++ b/CoreZen/Media/MPV/MPVConstants.h
@@ -72,3 +72,4 @@ extern const char* const kMPVCommandParam_absolute;
 extern const char* const kMPVCommandParam_absolute_percent;
 extern const char* const kMPVCommandParam_keyframes;
 extern const char* const kMPVCommandParam_exact;
+extern const char* const kMPVCommandParam_replace;

--- a/CoreZen/Media/MPV/MPVConstants.m
+++ b/CoreZen/Media/MPV/MPVConstants.m
@@ -72,3 +72,4 @@ const char* const kMPVCommandParam_absolute =			"absolute";
 const char* const kMPVCommandParam_absolute_percent =	"absolute-percent";
 const char* const kMPVCommandParam_keyframes =			"keyframes";
 const char* const kMPVCommandParam_exact =				"exact";
+const char* const kMPVCommandParam_replace =			"replace";

--- a/CoreZen/Media/MPV/MPVPlayerController.m
+++ b/CoreZen/Media/MPV/MPVPlayerController.m
@@ -276,8 +276,6 @@ static void zen_mpv_wakeup(void *ctx);
 				break;
 			}
 			case MPV_EVENT_PROPERTY_CHANGE: {
-				mpv_event_property *property = event->data;
-
 				mpv_node node = {};
 				if (mpv_event_to_node(&node, event) == MPV_ERROR_SUCCESS) {
 
@@ -309,18 +307,19 @@ static void zen_mpv_wakeup(void *ctx);
 						}
 					}
 					
-					NSLog(@"MPV_EVENT_PROPERTY_CHANGE (%llu): %s", observerID, property->name);
+					// mpv_event_property *property = event->data;
+					// NSLog(@"MPV_EVENT_PROPERTY_CHANGE (%llu): %s", observerID, property->name);
 
 					if (propertyName && valueNode && observerID == self.identifier) {
 						if (zen_mpv_compare_strings(kMPVProperty_pause, propertyName)) {
 							BOOL paused = (BOOL)valueNode->u.flag;
-							NSLog(@"Paused: %d", paused);
+							// NSLog(@"Paused: %d", paused);
 							dispatch_async(dispatch_get_main_queue(), ^{
 								self.player.paused = paused;
 							});
 						} else if (zen_mpv_compare_strings(kMPVProperty_percent_pos, propertyName)) {
 							double percentPos = valueNode->u.double_;
-							NSLog(@"Position: %f", percentPos);
+							// NSLog(@"Position: %f", percentPos);
 							dispatch_async(dispatch_get_main_queue(), ^{
 								self.player.positionPercent = percentPos;
 							});

--- a/CoreZen/Media/MPV/MPVPlayerController.m
+++ b/CoreZen/Media/MPV/MPVPlayerController.m
@@ -99,25 +99,6 @@ static void zen_mpv_wakeup(void *ctx);
 		// Observe properties
 		mpv_observe_property(_mpvHandle, _identifier, kMPVProperty_percent_pos, MPV_FORMAT_NODE);
 		mpv_observe_property(_mpvHandle, _identifier, kMPVProperty_pause, MPV_FORMAT_NODE);
-		
-		// Load the initial file
-		// TODO: Remove this, load files dynamically via API
-		const char* loadCommand[] = {
-			kMPVCommand_loadfile,
-			player.fileURL.path.fileSystemRepresentation,
-			"append",
-			nil
-		};
-		[self mpvCommand:loadCommand];
-
-		const char* playCommand[] = {
-			kMPVCommand_playlist_play_index,
-			"0",
-			nil
-		};
-		[self mpvCommand:playCommand];
-
-		[self pausePlayback];
 	}
 	return self;
 }
@@ -163,6 +144,18 @@ static void zen_mpv_wakeup(void *ctx);
 	
 - (void *)playerHandle {
 	return _mpvHandle;
+}
+
+- (void)openFileURL:(NSURL *)url {
+	const char* loadCommand[] = {
+		kMPVCommand_loadfile,
+		url.path.fileSystemRepresentation,
+		kMPVCommandParam_replace,
+		nil
+	};
+	[self mpvCommand:loadCommand];
+	
+	[self pausePlayback];
 }
 
 - (void)startPlayback {

--- a/CoreZen/Media/MPV/MPVPlayerController.m
+++ b/CoreZen/Media/MPV/MPVPlayerController.m
@@ -99,6 +99,7 @@ static void zen_mpv_wakeup(void *ctx);
 		// Observe properties
 		mpv_observe_property(_mpvHandle, _identifier, kMPVProperty_percent_pos, MPV_FORMAT_NODE);
 		mpv_observe_property(_mpvHandle, _identifier, kMPVProperty_pause, MPV_FORMAT_NODE);
+		mpv_observe_property(_mpvHandle, _identifier, kMPVProperty_path, MPV_FORMAT_NODE);
 	}
 	return self;
 }
@@ -322,6 +323,13 @@ static void zen_mpv_wakeup(void *ctx);
 							NSLog(@"Position: %f", percentPos);
 							dispatch_async(dispatch_get_main_queue(), ^{
 								self.player.positionPercent = percentPos;
+							});
+						} else if (zen_mpv_compare_strings(kMPVProperty_path, propertyName)) {
+							NSString *path = zen_mpv_to_nsstring(valueNode->u.string);
+							NSURL *url = [NSURL fileURLWithPath:path];
+							// NSLog(@"Path: %@", url);
+							dispatch_async(dispatch_get_main_queue(), ^{
+								self.player.fileURL = url;
 							});
 						}
 					}

--- a/CoreZen/Media/MediaPlayer.h
+++ b/CoreZen/Media/MediaPlayer.h
@@ -12,8 +12,6 @@
 
 @interface ZENMediaPlayer : NSObject <ZENIdentifiable>
 
-- (instancetype)initWithFileURL:(NSURL*)url;
-
 @property (nonatomic, strong, readonly) ZENMediaPlayerView *playerView;
 
 // Observe these properties for updates to the UI. They will only change on the main thread.
@@ -27,6 +25,8 @@
 
 // Call before application terminates to terminate all ZENMediaPlayer instances
 + (void)terminateAllPlayers;
+
+- (void)loadFileURL:(NSURL *)url;
 
 - (void)startPlayback;
 - (void)pausePlayback;

--- a/CoreZen/Media/MediaPlayer.m
+++ b/CoreZen/Media/MediaPlayer.m
@@ -22,7 +22,6 @@ ZENObjectCache* ZENGetWeakMediaPlayerCache(void) {
 @interface ZENMediaPlayer ()
 
 @property (nonatomic) BOOL terminated;
-@property (nonatomic, strong) NSURL *fileURL;
 
 @end
 

--- a/CoreZen/Media/MediaPlayer.m
+++ b/CoreZen/Media/MediaPlayer.m
@@ -30,11 +30,10 @@ ZENObjectCache* ZENGetWeakMediaPlayerCache(void) {
 
 @synthesize identifier=_identifier;
 
-- (instancetype)initWithFileURL:(NSURL*)url {
+- (instancetype)init {
 	self = [super init];
 	if (self) {
 		_terminated = NO;
-		_fileURL = url;
 		_playerController = [[ZENMPVPlayerController alloc] initWithPlayer:self];
 		_identifier = _playerController.identifier;
 		
@@ -86,6 +85,10 @@ ZENObjectCache* ZENGetWeakMediaPlayerCache(void) {
 		[self pausePlayback];
 		self.playerView = nil;
 	}
+}
+
+- (void)loadFileURL:(NSURL *)url {
+	[self.playerController openFileURL:url];
 }
 
 - (void)startPlayback {

--- a/CoreZen/Media/Views/MediaPlayerCTIView.m
+++ b/CoreZen/Media/Views/MediaPlayerCTIView.m
@@ -7,12 +7,14 @@
 
 #import "MediaPlayerCTIView.h"
 #import "MediaPlayer.h"
+#import "MediaPlayerPeekView.h"
 
 static void* ObserverContext = &ObserverContext;
 
 @interface ZENMediaPlayerCTIView ()
 
 @property (nonatomic, weak) IBOutlet NSSlider *slider;
+@property (nonatomic, weak) IBOutlet ZENMediaPlayerPeekView *peekView;
 
 - (IBAction)sliderChanged:(id)sender;
 
@@ -32,6 +34,7 @@ static void* ObserverContext = &ObserverContext;
 	[super initCommon];
 	
 	self.scrubbing = NO;
+	self.previewing = NO;
 	
 	self.slider.minValue = 0.0;
 	self.slider.maxValue = 100.0;

--- a/CoreZen/Media/Views/MediaPlayerCTIView.m
+++ b/CoreZen/Media/Views/MediaPlayerCTIView.m
@@ -49,9 +49,9 @@ static void* ObserverContext = &ObserverContext;
 - (void)updateTrackingAreas {
 	[super updateTrackingAreas];
 	
-	if (self.slider.trackingAreas.count > 0) {
+	if (self.slider.cell.controlView.trackingAreas.count > 0) {
 		NSTrackingArea *area = self.slider.trackingAreas.firstObject;
-		[self.slider removeTrackingArea:area];
+		[self.slider.cell.controlView removeTrackingArea:area];
 	}
 	
 	NSRect rect = self.slider.bounds;
@@ -59,7 +59,7 @@ static void* ObserverContext = &ObserverContext;
 	NSDictionary *userData = nil;
 	
 	NSTrackingArea *area = [[NSTrackingArea alloc] initWithRect:rect options:options owner:self userInfo:userData];
-	[self.slider addTrackingArea:area];
+	[self.slider.cell.controlView addTrackingArea:area];
 }
 
 - (void)attachPlayer:(ZENMediaPlayer *)player {

--- a/CoreZen/Media/Views/MediaPlayerCTIView.m
+++ b/CoreZen/Media/Views/MediaPlayerCTIView.m
@@ -18,6 +18,7 @@ static void* ObserverContext = &ObserverContext;
 
 @property (nonatomic, weak) ZENMediaPlayer *player;
 @property (nonatomic) BOOL scrubbing;
+@property (nonatomic) BOOL previewing;
 
 @end
 
@@ -96,6 +97,8 @@ static void* ObserverContext = &ObserverContext;
 
 - (void)mouseEntered:(NSEvent *)event {
 	[super mouseEntered:event];
+	
+	self.previewing = YES;
 }
 
 - (void)mouseMoved:(NSEvent *)event {
@@ -104,6 +107,8 @@ static void* ObserverContext = &ObserverContext;
 
 - (void)mouseExited:(NSEvent *)event {
 	[super mouseExited:event];
+	
+	self.previewing = NO;
 }
 
 @end

--- a/CoreZen/Media/Views/MediaPlayerPeekView.h
+++ b/CoreZen/Media/Views/MediaPlayerPeekView.h
@@ -1,0 +1,14 @@
+//
+//  MediaPlayerPeekView.h
+//  CoreZen
+//
+//  Created by Zach Nelson on 11/10/22.
+//
+
+#import <Cocoa/Cocoa.h>
+
+@interface ZENMediaPlayerPeekView : NSView
+
+@property (nonatomic, weak) IBOutlet NSImageView *imageView;
+
+@end

--- a/CoreZen/Media/Views/MediaPlayerPeekView.m
+++ b/CoreZen/Media/Views/MediaPlayerPeekView.m
@@ -21,7 +21,7 @@
 	self.layer.masksToBounds = YES;
 	self.layer.shadowRadius = 2;
 	self.layer.borderWidth = 1;
-	self.layer.borderColor = CGColorCreateSRGB(1.f, 0.f, 0.f, 1.f);
+	self.layer.borderColor = CGColorCreateGenericGray(0.7, 0.6);
 	
 	self.imageView.wantsLayer = YES;
 	self.imageView.layer.cornerRadius = 4;

--- a/CoreZen/Media/Views/MediaPlayerPeekView.m
+++ b/CoreZen/Media/Views/MediaPlayerPeekView.m
@@ -1,0 +1,47 @@
+//
+//  MediaPlayerPeekView.m
+//  CoreZen
+//
+//  Created by Zach Nelson on 11/10/22.
+//
+
+#import "MediaPlayerPeekView.h"
+
+@interface ZENMediaPlayerPeekView ()
+
+- (void)initCommon;
+
+@end
+
+@implementation ZENMediaPlayerPeekView
+
+- (void)initCommon {
+	self.wantsLayer = YES;
+	self.layer.cornerRadius = 4;
+	self.layer.masksToBounds = YES;
+	self.layer.shadowRadius = 2;
+	self.layer.borderWidth = 1;
+	self.layer.borderColor = CGColorCreateSRGB(1.f, 0.f, 0.f, 1.f);
+	
+	self.imageView.wantsLayer = YES;
+	self.imageView.layer.cornerRadius = 4;
+	self.imageView.layer.masksToBounds = YES;
+}
+
+- (instancetype)initWithFrame:(NSRect)frameRect {
+	self = [super initWithFrame:frameRect];
+	if (self) {
+		[self initCommon];
+	}
+	return self;
+}
+
+- (instancetype)initWithCoder:(NSCoder *)coder {
+	self = [super initWithCoder:coder];
+	if (self) {
+		[self initCommon];
+	}
+	return self;
+}
+
+@end

--- a/CoreZen/Media/Views/Nibs/ZENMediaPlayerCTIView.xib
+++ b/CoreZen/Media/Views/Nibs/ZENMediaPlayerCTIView.xib
@@ -34,5 +34,27 @@
             </constraints>
             <point key="canvasLocation" x="79" y="154"/>
         </customView>
+        <customView wantsLayer="YES" translatesAutoresizingMaskIntoConstraints="NO" id="CbS-EO-qut" customClass="ZENMediaPlayerPeekView">
+            <rect key="frame" x="0.0" y="0.0" width="316" height="135"/>
+            <subviews>
+                <imageView horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="MWa-HD-KfO">
+                    <rect key="frame" x="0.0" y="0.0" width="316" height="135"/>
+                    <imageCell key="cell" refusesFirstResponder="YES" alignment="left" imageScaling="proportionallyDown" id="Xjq-g7-s7V"/>
+                </imageView>
+            </subviews>
+            <constraints>
+                <constraint firstItem="MWa-HD-KfO" firstAttribute="leading" secondItem="CbS-EO-qut" secondAttribute="leading" id="AM1-Ha-1TS"/>
+                <constraint firstItem="MWa-HD-KfO" firstAttribute="top" secondItem="CbS-EO-qut" secondAttribute="top" id="RtI-YR-F3f"/>
+                <constraint firstAttribute="trailing" secondItem="MWa-HD-KfO" secondAttribute="trailing" id="TRu-vE-aaF"/>
+                <constraint firstAttribute="bottom" secondItem="MWa-HD-KfO" secondAttribute="bottom" id="vLa-hu-HTO"/>
+            </constraints>
+            <shadow key="shadow">
+                <color key="color" white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+            </shadow>
+            <connections>
+                <outlet property="imageView" destination="MWa-HD-KfO" id="k5S-UM-BEm"/>
+            </connections>
+            <point key="canvasLocation" x="-441" y="-23.5"/>
+        </customView>
     </objects>
 </document>

--- a/CoreZen/Media/Views/Nibs/ZENMediaPlayerCTIView.xib
+++ b/CoreZen/Media/Views/Nibs/ZENMediaPlayerCTIView.xib
@@ -8,7 +8,7 @@
     <objects>
         <customObject id="-2" userLabel="File's Owner" customClass="ZENMediaPlayerCTIView">
             <connections>
-                <outlet property="peekView" destination="CbS-EO-qut" id="tdS-9c-7Mk"/>
+                <outlet property="peekView" destination="Zja-qd-VVX" id="feT-zd-kuv"/>
                 <outlet property="rootView" destination="c22-O7-iKe" id="ElT-Au-SCX"/>
                 <outlet property="slider" destination="Kcy-pW-27Q" id="Ger-lQ-7ny"/>
             </connections>
@@ -34,27 +34,29 @@
             </constraints>
             <point key="canvasLocation" x="79" y="154"/>
         </customView>
-        <customView wantsLayer="YES" translatesAutoresizingMaskIntoConstraints="NO" id="CbS-EO-qut" customClass="ZENMediaPlayerPeekView">
-            <rect key="frame" x="0.0" y="0.0" width="316" height="135"/>
+        <customView wantsLayer="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Zja-qd-VVX" customClass="ZENMediaPlayerPeekView">
+            <rect key="frame" x="0.0" y="0.0" width="100" height="96"/>
             <subviews>
-                <imageView horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="MWa-HD-KfO">
-                    <rect key="frame" x="0.0" y="0.0" width="316" height="135"/>
-                    <imageCell key="cell" refusesFirstResponder="YES" alignment="left" imageScaling="proportionallyDown" id="Xjq-g7-s7V"/>
+                <imageView horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="3qo-GU-e3I">
+                    <rect key="frame" x="0.0" y="0.0" width="100" height="96"/>
+                    <imageCell key="cell" refusesFirstResponder="YES" alignment="left" imageScaling="proportionallyDown" id="sWl-hQ-Oea"/>
                 </imageView>
             </subviews>
             <constraints>
-                <constraint firstItem="MWa-HD-KfO" firstAttribute="leading" secondItem="CbS-EO-qut" secondAttribute="leading" id="AM1-Ha-1TS"/>
-                <constraint firstItem="MWa-HD-KfO" firstAttribute="top" secondItem="CbS-EO-qut" secondAttribute="top" id="RtI-YR-F3f"/>
-                <constraint firstAttribute="trailing" secondItem="MWa-HD-KfO" secondAttribute="trailing" id="TRu-vE-aaF"/>
-                <constraint firstAttribute="bottom" secondItem="MWa-HD-KfO" secondAttribute="bottom" id="vLa-hu-HTO"/>
+                <constraint firstAttribute="trailing" secondItem="3qo-GU-e3I" secondAttribute="trailing" id="5qJ-Kw-wfI"/>
+                <constraint firstItem="3qo-GU-e3I" firstAttribute="leading" secondItem="Zja-qd-VVX" secondAttribute="leading" id="6bb-lF-fOo"/>
+                <constraint firstAttribute="height" relation="greaterThanOrEqual" priority="100" constant="100" id="Is1-28-xpq"/>
+                <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="100" id="Lfa-9b-9fe"/>
+                <constraint firstAttribute="bottom" secondItem="3qo-GU-e3I" secondAttribute="bottom" id="WC7-wo-IGc"/>
+                <constraint firstItem="3qo-GU-e3I" firstAttribute="top" secondItem="Zja-qd-VVX" secondAttribute="top" id="bvY-Rw-7Tv"/>
             </constraints>
             <shadow key="shadow">
                 <color key="color" white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
             </shadow>
             <connections>
-                <outlet property="imageView" destination="MWa-HD-KfO" id="k5S-UM-BEm"/>
+                <outlet property="imageView" destination="3qo-GU-e3I" id="VXS-I3-QNl"/>
             </connections>
-            <point key="canvasLocation" x="-441" y="-23.5"/>
+            <point key="canvasLocation" x="-577" y="-68"/>
         </customView>
     </objects>
 </document>

--- a/CoreZen/Media/Views/Nibs/ZENMediaPlayerCTIView.xib
+++ b/CoreZen/Media/Views/Nibs/ZENMediaPlayerCTIView.xib
@@ -8,7 +8,7 @@
     <objects>
         <customObject id="-2" userLabel="File's Owner" customClass="ZENMediaPlayerCTIView">
             <connections>
-                <outlet property="peekView" destination="CbS-EO-qut" id="rVG-4b-NNf"/>
+                <outlet property="peekView" destination="CbS-EO-qut" id="tdS-9c-7Mk"/>
                 <outlet property="rootView" destination="c22-O7-iKe" id="ElT-Au-SCX"/>
                 <outlet property="slider" destination="Kcy-pW-27Q" id="Ger-lQ-7ny"/>
             </connections>

--- a/CoreZen/Queue/WorkQueue+Private.h
+++ b/CoreZen/Queue/WorkQueue+Private.h
@@ -1,0 +1,14 @@
+//
+//  WorkQueue+Private.h
+//  CoreZen
+//
+//  Created by Zach Nelson on 11/14/22.
+//
+
+#import <CoreZen/WorkQueue.h>
+
+@interface ZENWorkQueueMultiToken : ZENWorkQueueToken
+
+- (instancetype)initWithTokens:(NSArray<ZENWorkQueueToken *> *)tokens;
+
+@end

--- a/CoreZen/Queue/WorkQueue.h
+++ b/CoreZen/Queue/WorkQueue.h
@@ -6,6 +6,7 @@
 //
 
 #import <Foundation/Foundation.h>
+#import <CoreZen/WorkQueueTypes.h>
 
 @interface ZENWorkQueueToken : NSObject
 
@@ -25,8 +26,6 @@
 - (BOOL)terminate;
 
 @end
-
-typedef ZENWorkQueueToken ZENCancelToken;
 
 typedef void (^ZENWorkQueueBlock)(void);
 typedef void (^ZENWorkQueueCancelBlock)(ZENCancelToken *canceled);

--- a/CoreZen/Queue/WorkQueueTypes.h
+++ b/CoreZen/Queue/WorkQueueTypes.h
@@ -1,0 +1,10 @@
+//
+//  WorkQueueTypes.h
+//  CoreZen
+//
+//  Created by Zach Nelson on 11/14/22.
+//
+
+@class ZENWorkQueueToken;
+
+typedef ZENWorkQueueToken ZENCancelToken;


### PR DESCRIPTION
* Media player now has an API to open files instead of taking a file path at construction. The same media player can be used to play back many media files.
* mpv player controller observes the player file path and updates a KVO property on the player
* CTI view holds a peek view and frame renderer for previewing the frame under the mouse
* CTI view fetches preview frames from frame renderer and when they become available shows the peek preview on mouse over
* CTI view hides peek view while slider is scrubbing
* CTI view observes player file path and rebuilds frame renderer and previews as necessary
* Async frame renders return a cancel token
* Frame renderer now has an API to fetch a number of frames spread evenly across a video, which also returns a (single, compound) cancel token to cancel the whole batch of requests